### PR TITLE
Resolve Crashing Local Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <repository>
       <id>sprin-libs-repo</id>
       <name>Spring Lib Release repository</name>
-      <url>http://repo.spring.io/libs-release</url>
+      <url>https://repo.spring.io/libs-release</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
Repos.spring requires https even if unauthenticated. This update updates `pom.xml` for this constraint.

Without this change, a simple `mvn compile` will not run.

CC @anmeng10101 