### PR TITLE
enable double quotes for yaml contents

### DIFF
--- a/src/main/java/com/microsoft/util/YamlUtil.java
+++ b/src/main/java/com/microsoft/util/YamlUtil.java
@@ -32,7 +32,6 @@ public class YamlUtil {
     private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory()
         .disable(Feature.WRITE_DOC_START_MARKER)
         .disable(Feature.SPLIT_LINES)
-        .enable(YAMLGenerator.Feature.MINIMIZE_QUOTES)
     )
         .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
         .setSerializationInclusion(Include.NON_NULL)

--- a/src/test/java/com/microsoft/samples/SuperHero.java
+++ b/src/test/java/com/microsoft/samples/SuperHero.java
@@ -107,4 +107,16 @@ public class SuperHero extends Person implements Serializable, Cloneable {
     String getHobby() {
         return hobby;
     }
+
+    /**
+     * Returns a FileStoreAttributeView of the given type.
+     * <p>
+     * This method always returns null as no {@link FileStoreAttributeView} is currently supported.
+     *
+     * @param aClass a class
+     * @return null
+     */
+    public <V extends Class> V ReturnNull(Class<V> aClass) {
+        return null;
+    }
 }

--- a/src/test/java/com/microsoft/util/YamlUtilTest.java
+++ b/src/test/java/com/microsoft/util/YamlUtilTest.java
@@ -26,24 +26,24 @@ public class YamlUtilTest {
 
         assertThat("Wrong result", result, is(""
             + "items:\n"
-            + "- uid: Some uid 3\n"
-            + "  id: Some id3\n"
-            + "  href: Some href3\n"
-            + "  type: method\n"
+            + "- uid: \"Some uid 3\"\n"
+            + "  id: \"Some id3\"\n"
+            + "  href: \"Some href3\"\n"
+            + "  type: \"method\"\n"
             + "  syntax:\n"
             + "    parameters:\n"
-            + "    - description: Some desc 3\n"
-            + "      name: Some name 3\n"
-            + "      type: <xref href=\"Some type 3?alt=Some type 3&text=Some type 3\" data-throw-if-not-resolved=\"False\" />\n"
+            + "    - description: \"Some desc 3\"\n"
+            + "      name: \"Some name 3\"\n"
+            + "      type: \"<xref href=\\\"Some type 3?alt=Some type 3&text=Some type 3\\\" data-throw-if-not-resolved=\\\"False\\\" />\"\n"
             + "references:\n"
-            + "- uid: Some uid 5\n"
-            + "  id: Some id5\n"
-            + "  href: Some href5\n"
+            + "- uid: \"Some uid 5\"\n"
+            + "  id: \"Some id5\"\n"
+            + "  href: \"Some href5\"\n"
             + "  syntax:\n"
             + "    parameters:\n"
-            + "    - description: Some desc 5\n"
-            + "      name: Some name 5\n"
-            + "      type: <xref href=\"Some type 5?alt=Some type 5&text=Some type 5\" data-throw-if-not-resolved=\"False\" />\n"));
+            + "    - description: \"Some desc 5\"\n"
+            + "      name: \"Some name 5\"\n"
+            + "      type: \"<xref href=\\\"Some type 5?alt=Some type 5&text=Some type 5\\\" data-throw-if-not-resolved=\\\"False\\\" />\"\n"));
     }
 
     @Test

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.BasePartnerComponent.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.BasePartnerComponent.yml
@@ -1,22 +1,22 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.BasePartnerComponent.BasePartnerComponent*
-fullName: com.microsoft.samples.BasePartnerComponent<TContext>.BasePartnerComponent
-name: BasePartnerComponent
-nameWithType: BasePartnerComponent<TContext>.BasePartnerComponent
+uid: "com.microsoft.samples.BasePartnerComponent.BasePartnerComponent*"
+fullName: "com.microsoft.samples.BasePartnerComponent<TContext>.BasePartnerComponent"
+name: "BasePartnerComponent"
+nameWithType: "BasePartnerComponent<TContext>.BasePartnerComponent"
 members:
-- uid: com.microsoft.samples.BasePartnerComponent.BasePartnerComponent(com.microsoft.samples.IPartner,TContext)
-  fullName: com.microsoft.samples.BasePartnerComponent<TContext>.BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)
-  name: BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)
-  nameWithType: BasePartnerComponent<TContext>.BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)
-  summary: Initializes a new instance of the BasePartnerComponent class.
+- uid: "com.microsoft.samples.BasePartnerComponent.BasePartnerComponent(com.microsoft.samples.IPartner,TContext)"
+  fullName: "com.microsoft.samples.BasePartnerComponent<TContext>.BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)"
+  name: "BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)"
+  nameWithType: "BasePartnerComponent<TContext>.BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)"
+  summary: "Initializes a new instance of the BasePartnerComponent class."
   parameters:
-  - description: The root partner operations that created this component.
-    name: rootPartnerOperations
-    type: <xref href="com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner" data-throw-if-not-resolved="False" />
-  - description: A component context object to work with.
-    name: componentContext
-    type: <xref href="TContext?alt=TContext&text=TContext" data-throw-if-not-resolved="False" />
-  syntax: protected BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)
-type: constructor
+  - description: "The root partner operations that created this component."
+    name: "rootPartnerOperations"
+    type: "<xref href=\"com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner\" data-throw-if-not-resolved=\"False\" />"
+  - description: "A component context object to work with."
+    name: "componentContext"
+    type: "<xref href=\"TContext?alt=TContext&text=TContext\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "protected BasePartnerComponent(IPartner rootPartnerOperations, TContext componentContext)"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.testBase.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.testBase.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.BasePartnerComponent.testBase*
-fullName: com.microsoft.samples.BasePartnerComponent<TContext>.testBase
-name: testBase
-nameWithType: BasePartnerComponent<TContext>.testBase
+uid: "com.microsoft.samples.BasePartnerComponent.testBase*"
+fullName: "com.microsoft.samples.BasePartnerComponent<TContext>.testBase"
+name: "testBase"
+nameWithType: "BasePartnerComponent<TContext>.testBase"
 members:
-- uid: com.microsoft.samples.BasePartnerComponent.testBase()
-  fullName: com.microsoft.samples.BasePartnerComponent<TContext>.testBase()
-  name: testBase()
-  nameWithType: BasePartnerComponent<TContext>.testBase()
-  syntax: protected void testBase()
-type: method
+- uid: "com.microsoft.samples.BasePartnerComponent.testBase()"
+  fullName: "com.microsoft.samples.BasePartnerComponent<TContext>.testBase()"
+  name: "testBase()"
+  nameWithType: "BasePartnerComponent<TContext>.testBase()"
+  syntax: "protected void testBase()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.testInherited.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.testInherited.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.BasePartnerComponent.testInherited*
-fullName: com.microsoft.samples.BasePartnerComponent<TContext>.testInherited
-name: testInherited
-nameWithType: BasePartnerComponent<TContext>.testInherited
+uid: "com.microsoft.samples.BasePartnerComponent.testInherited*"
+fullName: "com.microsoft.samples.BasePartnerComponent<TContext>.testInherited"
+name: "testInherited"
+nameWithType: "BasePartnerComponent<TContext>.testInherited"
 members:
-- uid: com.microsoft.samples.BasePartnerComponent.testInherited()
-  fullName: com.microsoft.samples.BasePartnerComponent<TContext>.testInherited()
-  name: testInherited()
-  nameWithType: BasePartnerComponent<TContext>.testInherited()
-  syntax: protected void testInherited()
-type: method
+- uid: "com.microsoft.samples.BasePartnerComponent.testInherited()"
+  fullName: "com.microsoft.samples.BasePartnerComponent<TContext>.testInherited()"
+  name: "testInherited()"
+  nameWithType: "BasePartnerComponent<TContext>.testInherited()"
+  syntax: "protected void testInherited()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponent.yml
@@ -1,31 +1,31 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.BasePartnerComponent
-fullName: com.microsoft.samples.BasePartnerComponent<TContext>
-name: BasePartnerComponent<TContext>
-nameWithType: BasePartnerComponent<TContext>
-summary: Holds common partner component properties and behavior. All components should inherit from this class. The context object type.
+uid: "com.microsoft.samples.BasePartnerComponent"
+fullName: "com.microsoft.samples.BasePartnerComponent<TContext>"
+name: "BasePartnerComponent<TContext>"
+nameWithType: "BasePartnerComponent<TContext>"
+summary: "Holds common partner component properties and behavior. All components should inherit from this class. The context object type."
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public abstract class BasePartnerComponent<TContext>
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public abstract class BasePartnerComponent<TContext>"
 constructors:
-- com.microsoft.samples.BasePartnerComponent.BasePartnerComponent(com.microsoft.samples.IPartner,TContext)
+- "com.microsoft.samples.BasePartnerComponent.BasePartnerComponent(com.microsoft.samples.IPartner,TContext)"
 methods:
-- com.microsoft.samples.BasePartnerComponent.testBase()
-- com.microsoft.samples.BasePartnerComponent.testInherited()
-type: class
+- "com.microsoft.samples.BasePartnerComponent.testBase()"
+- "com.microsoft.samples.BasePartnerComponent.testInherited()"
+type: "class"
 typeParameters:
-- name: TContext
+- name: "TContext"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString.yml
@@ -1,32 +1,32 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString*
-fullName: com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString
-name: BasePartnerComponentString
-nameWithType: BasePartnerComponentString.BasePartnerComponentString
+uid: "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString*"
+fullName: "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString"
+name: "BasePartnerComponentString"
+nameWithType: "BasePartnerComponentString.BasePartnerComponentString"
 members:
-- uid: com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner)
-  fullName: com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations)
-  name: BasePartnerComponentString(IPartner rootPartnerOperations)
-  nameWithType: BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations)
-  summary: Initializes a new instance of the BasePartnerComponent class.
+- uid: "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner)"
+  fullName: "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations)"
+  name: "BasePartnerComponentString(IPartner rootPartnerOperations)"
+  nameWithType: "BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations)"
+  summary: "Initializes a new instance of the BasePartnerComponent class."
   parameters:
-  - description: The root partner operations that created this component.
-    name: rootPartnerOperations
-    type: <xref href="com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner" data-throw-if-not-resolved="False" />
-  syntax: protected BasePartnerComponentString(IPartner rootPartnerOperations)
-- uid: com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner,java.lang.String)
-  fullName: com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)
-  name: BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)
-  nameWithType: BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)
-  summary: Initializes a new instance of the BasePartnerComponent class.
+  - description: "The root partner operations that created this component."
+    name: "rootPartnerOperations"
+    type: "<xref href=\"com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "protected BasePartnerComponentString(IPartner rootPartnerOperations)"
+- uid: "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner,java.lang.String)"
+  fullName: "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)"
+  name: "BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)"
+  nameWithType: "BasePartnerComponentString.BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)"
+  summary: "Initializes a new instance of the BasePartnerComponent class."
   parameters:
-  - description: The root partner operations that created this component.
-    name: rootPartnerOperations
-    type: <xref href="com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner" data-throw-if-not-resolved="False" />
-  - description: A component context object to work with.
-    name: componentContext
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: protected BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)
-type: constructor
+  - description: "The root partner operations that created this component."
+    name: "rootPartnerOperations"
+    type: "<xref href=\"com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner\" data-throw-if-not-resolved=\"False\" />"
+  - description: "A component context object to work with."
+    name: "componentContext"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "protected BasePartnerComponentString(IPartner rootPartnerOperations, String componentContext)"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponentString.testInherited.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponentString.testInherited.yml
@@ -1,15 +1,15 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.BasePartnerComponentString.testInherited*
-fullName: com.microsoft.samples.BasePartnerComponentString.testInherited
-name: testInherited
-nameWithType: BasePartnerComponentString.testInherited
+uid: "com.microsoft.samples.BasePartnerComponentString.testInherited*"
+fullName: "com.microsoft.samples.BasePartnerComponentString.testInherited"
+name: "testInherited"
+nameWithType: "BasePartnerComponentString.testInherited"
 members:
-- uid: com.microsoft.samples.BasePartnerComponentString.testInherited()
-  fullName: com.microsoft.samples.BasePartnerComponentString.testInherited()
-  name: testInherited()
-  nameWithType: BasePartnerComponentString.testInherited()
-  overridden: com.microsoft.samples.BasePartnerComponent.testInherited()
-  syntax: protected void testInherited()
-type: method
+- uid: "com.microsoft.samples.BasePartnerComponentString.testInherited()"
+  fullName: "com.microsoft.samples.BasePartnerComponentString.testInherited()"
+  name: "testInherited()"
+  nameWithType: "BasePartnerComponentString.testInherited()"
+  overridden: "com.microsoft.samples.BasePartnerComponent.testInherited()"
+  syntax: "protected void testInherited()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponentString.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.BasePartnerComponentString.yml
@@ -1,32 +1,32 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.BasePartnerComponentString
-fullName: com.microsoft.samples.BasePartnerComponentString
-name: BasePartnerComponentString
-nameWithType: BasePartnerComponentString
-summary: Holds common partner component properties and behavior. The context is string type by default.
+uid: "com.microsoft.samples.BasePartnerComponentString"
+fullName: "com.microsoft.samples.BasePartnerComponentString"
+name: "BasePartnerComponentString"
+nameWithType: "BasePartnerComponentString"
+summary: "Holds common partner component properties and behavior. The context is string type by default."
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.BasePartnerComponent" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.BasePartnerComponent\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- com.microsoft.samples.BasePartnerComponent.testBase()
-- com.microsoft.samples.BasePartnerComponent.testInherited()
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public abstract class BasePartnerComponentString extends BasePartnerComponent<String>
+- "com.microsoft.samples.BasePartnerComponent.testBase()"
+- "com.microsoft.samples.BasePartnerComponent.testInherited()"
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public abstract class BasePartnerComponentString extends BasePartnerComponent<String>"
 constructors:
-- com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner)
-- com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner,java.lang.String)
+- "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner)"
+- "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString(com.microsoft.samples.IPartner,java.lang.String)"
 methods:
-- com.microsoft.samples.BasePartnerComponentString.testInherited()
-type: class
+- "com.microsoft.samples.BasePartnerComponentString.testInherited()"
+type: "class"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.IPartner.getCredentials.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.IPartner.getCredentials.yml
@@ -1,18 +1,18 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.IPartner.getCredentials*
-fullName: com.microsoft.samples.IPartner.getCredentials
-name: getCredentials
-nameWithType: IPartner.getCredentials
+uid: "com.microsoft.samples.IPartner.getCredentials*"
+fullName: "com.microsoft.samples.IPartner.getCredentials"
+name: "getCredentials"
+nameWithType: "IPartner.getCredentials"
 members:
-- uid: com.microsoft.samples.IPartner.getCredentials()
-  fullName: com.microsoft.samples.IPartner.getCredentials()
-  name: getCredentials()
-  nameWithType: IPartner.getCredentials()
-  summary: Gets the partner credentials.
-  syntax: public abstract String getCredentials()
+- uid: "com.microsoft.samples.IPartner.getCredentials()"
+  fullName: "com.microsoft.samples.IPartner.getCredentials()"
+  name: "getCredentials()"
+  nameWithType: "IPartner.getCredentials()"
+  summary: "Gets the partner credentials."
+  syntax: "public abstract String getCredentials()"
   returns:
-    description: The partner credentials.
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    description: "The partner credentials."
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.IPartner.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.IPartner.yml
@@ -1,12 +1,12 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.IPartner
-fullName: com.microsoft.samples.IPartner
-name: IPartner
-nameWithType: IPartner
-summary: The main entry point into using the partner SDK functionality. Represents a partner and encapsulates all the behavior attached to partners. Use this interface to get to the partner's customers, profiles, and customer orders, profiles and subscriptions and more.
-syntax: public interface IPartner
+uid: "com.microsoft.samples.IPartner"
+fullName: "com.microsoft.samples.IPartner"
+name: "IPartner"
+nameWithType: "IPartner"
+summary: "The main entry point into using the partner SDK functionality. Represents a partner and encapsulates all the behavior attached to partners. Use this interface to get to the partner's customers, profiles, and customer orders, profiles and subscriptions and more."
+syntax: "public interface IPartner"
 methods:
-- com.microsoft.samples.IPartner.getCredentials()
-type: interface
+- "com.microsoft.samples.IPartner.getCredentials()"
+type: "interface"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.KeyValuePair.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.KeyValuePair.yml
@@ -1,24 +1,24 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.KeyValuePair.KeyValuePair*
-fullName: com.microsoft.samples.KeyValuePair<K,V>.KeyValuePair
-name: KeyValuePair
-nameWithType: KeyValuePair<K,V>.KeyValuePair
+uid: "com.microsoft.samples.KeyValuePair.KeyValuePair*"
+fullName: "com.microsoft.samples.KeyValuePair<K,V>.KeyValuePair"
+name: "KeyValuePair"
+nameWithType: "KeyValuePair<K,V>.KeyValuePair"
 members:
-- uid: com.microsoft.samples.KeyValuePair.KeyValuePair()
-  fullName: com.microsoft.samples.KeyValuePair<K,V>.KeyValuePair()
-  name: KeyValuePair()
-  nameWithType: KeyValuePair<K,V>.KeyValuePair()
-  syntax: public KeyValuePair()
-- uid: com.microsoft.samples.KeyValuePair.KeyValuePair(K,V)
-  fullName: com.microsoft.samples.KeyValuePair<K,V>.KeyValuePair(K key, V value)
-  name: KeyValuePair(K key, V value)
-  nameWithType: KeyValuePair<K,V>.KeyValuePair(K key, V value)
+- uid: "com.microsoft.samples.KeyValuePair.KeyValuePair()"
+  fullName: "com.microsoft.samples.KeyValuePair<K,V>.KeyValuePair()"
+  name: "KeyValuePair()"
+  nameWithType: "KeyValuePair<K,V>.KeyValuePair()"
+  syntax: "public KeyValuePair()"
+- uid: "com.microsoft.samples.KeyValuePair.KeyValuePair(K,V)"
+  fullName: "com.microsoft.samples.KeyValuePair<K,V>.KeyValuePair(K key, V value)"
+  name: "KeyValuePair(K key, V value)"
+  nameWithType: "KeyValuePair<K,V>.KeyValuePair(K key, V value)"
   parameters:
-  - name: key
-    type: <xref href="K?alt=K&text=K" data-throw-if-not-resolved="False" />
-  - name: value
-    type: <xref href="V?alt=V&text=V" data-throw-if-not-resolved="False" />
-  syntax: public KeyValuePair(K key, V value)
-type: constructor
+  - name: "key"
+    type: "<xref href=\"K?alt=K&text=K\" data-throw-if-not-resolved=\"False\" />"
+  - name: "value"
+    type: "<xref href=\"V?alt=V&text=V\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public KeyValuePair(K key, V value)"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.getKey.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.getKey.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.KeyValuePair.getKey*
-fullName: com.microsoft.samples.KeyValuePair<K,V>.getKey
-name: getKey
-nameWithType: KeyValuePair<K,V>.getKey
+uid: "com.microsoft.samples.KeyValuePair.getKey*"
+fullName: "com.microsoft.samples.KeyValuePair<K,V>.getKey"
+name: "getKey"
+nameWithType: "KeyValuePair<K,V>.getKey"
 members:
-- uid: com.microsoft.samples.KeyValuePair.getKey()
-  fullName: com.microsoft.samples.KeyValuePair<K,V>.getKey()
-  name: getKey()
-  nameWithType: KeyValuePair<K,V>.getKey()
-  syntax: public K getKey()
+- uid: "com.microsoft.samples.KeyValuePair.getKey()"
+  fullName: "com.microsoft.samples.KeyValuePair<K,V>.getKey()"
+  name: "getKey()"
+  nameWithType: "KeyValuePair<K,V>.getKey()"
+  syntax: "public K getKey()"
   returns:
-    type: <xref href="K?alt=K&text=K" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"K?alt=K&text=K\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.getValue.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.getValue.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.KeyValuePair.getValue*
-fullName: com.microsoft.samples.KeyValuePair<K,V>.getValue
-name: getValue
-nameWithType: KeyValuePair<K,V>.getValue
+uid: "com.microsoft.samples.KeyValuePair.getValue*"
+fullName: "com.microsoft.samples.KeyValuePair<K,V>.getValue"
+name: "getValue"
+nameWithType: "KeyValuePair<K,V>.getValue"
 members:
-- uid: com.microsoft.samples.KeyValuePair.getValue()
-  fullName: com.microsoft.samples.KeyValuePair<K,V>.getValue()
-  name: getValue()
-  nameWithType: KeyValuePair<K,V>.getValue()
-  syntax: public V getValue()
+- uid: "com.microsoft.samples.KeyValuePair.getValue()"
+  fullName: "com.microsoft.samples.KeyValuePair<K,V>.getValue()"
+  name: "getValue()"
+  nameWithType: "KeyValuePair<K,V>.getValue()"
+  syntax: "public V getValue()"
   returns:
-    type: <xref href="V?alt=V&text=V" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"V?alt=V&text=V\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.KeyValuePair.yml
@@ -1,32 +1,32 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.KeyValuePair
-fullName: com.microsoft.samples.KeyValuePair<K,V>
-name: KeyValuePair<K,V>
-nameWithType: KeyValuePair<K,V>
+uid: "com.microsoft.samples.KeyValuePair"
+fullName: "com.microsoft.samples.KeyValuePair<K,V>"
+name: "KeyValuePair<K,V>"
+nameWithType: "KeyValuePair<K,V>"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class KeyValuePair<K,V>
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class KeyValuePair<K,V>"
 constructors:
-- com.microsoft.samples.KeyValuePair.KeyValuePair()
-- com.microsoft.samples.KeyValuePair.KeyValuePair(K,V)
+- "com.microsoft.samples.KeyValuePair.KeyValuePair()"
+- "com.microsoft.samples.KeyValuePair.KeyValuePair(K,V)"
 methods:
-- com.microsoft.samples.KeyValuePair.getKey()
-- com.microsoft.samples.KeyValuePair.getValue()
-type: class
+- "com.microsoft.samples.KeyValuePair.getKey()"
+- "com.microsoft.samples.KeyValuePair.getValue()"
+type: "class"
 typeParameters:
-- name: K
-- name: V
+- name: "K"
+- name: "V"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Link.Link.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Link.Link.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.Link.Link*
-fullName: com.microsoft.samples.Link.Link
-name: Link
-nameWithType: Link.Link
+uid: "com.microsoft.samples.Link.Link*"
+fullName: "com.microsoft.samples.Link.Link"
+name: "Link"
+nameWithType: "Link.Link"
 members:
-- uid: com.microsoft.samples.Link.Link()
-  fullName: com.microsoft.samples.Link.Link()
-  name: Link()
-  nameWithType: Link.Link()
-  syntax: public Link()
-type: constructor
+- uid: "com.microsoft.samples.Link.Link()"
+  fullName: "com.microsoft.samples.Link.Link()"
+  name: "Link()"
+  nameWithType: "Link.Link()"
+  syntax: "public Link()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Link.getHeaders.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Link.getHeaders.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.Link.getHeaders*
-fullName: com.microsoft.samples.Link.getHeaders
-name: getHeaders
-nameWithType: Link.getHeaders
+uid: "com.microsoft.samples.Link.getHeaders*"
+fullName: "com.microsoft.samples.Link.getHeaders"
+name: "getHeaders"
+nameWithType: "Link.getHeaders"
 members:
-- uid: com.microsoft.samples.Link.getHeaders()
-  fullName: com.microsoft.samples.Link.getHeaders()
-  name: getHeaders()
-  nameWithType: Link.getHeaders()
-  syntax: public Collection<KeyValuePair<String,String>> getHeaders()
+- uid: "com.microsoft.samples.Link.getHeaders()"
+  fullName: "com.microsoft.samples.Link.getHeaders()"
+  name: "getHeaders()"
+  nameWithType: "Link.getHeaders()"
+  syntax: "public Collection<KeyValuePair<String,String>> getHeaders()"
   returns:
-    type: <xref href="java.util.Collection?alt=java.util.Collection&text=Collection" data-throw-if-not-resolved="False" />&lt;<xref href="com.microsoft.samples.KeyValuePair?alt=com.microsoft.samples.KeyValuePair&text=KeyValuePair" data-throw-if-not-resolved="False" />&lt;<xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />,<xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />&gt;&gt;
-type: method
+    type: "<xref href=\"java.util.Collection?alt=java.util.Collection&text=Collection\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"com.microsoft.samples.KeyValuePair?alt=com.microsoft.samples.KeyValuePair&text=KeyValuePair\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />,<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />&gt;&gt;"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Link.getMethod.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Link.getMethod.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.Link.getMethod*
-fullName: com.microsoft.samples.Link.getMethod
-name: getMethod
-nameWithType: Link.getMethod
+uid: "com.microsoft.samples.Link.getMethod*"
+fullName: "com.microsoft.samples.Link.getMethod"
+name: "getMethod"
+nameWithType: "Link.getMethod"
 members:
-- uid: com.microsoft.samples.Link.getMethod()
-  fullName: com.microsoft.samples.Link.getMethod()
-  name: getMethod()
-  nameWithType: Link.getMethod()
-  syntax: public String getMethod()
+- uid: "com.microsoft.samples.Link.getMethod()"
+  fullName: "com.microsoft.samples.Link.getMethod()"
+  name: "getMethod()"
+  nameWithType: "Link.getMethod()"
+  syntax: "public String getMethod()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Link.setHeaders.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Link.setHeaders.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.Link.setHeaders*
-fullName: com.microsoft.samples.Link.setHeaders
-name: setHeaders
-nameWithType: Link.setHeaders
+uid: "com.microsoft.samples.Link.setHeaders*"
+fullName: "com.microsoft.samples.Link.setHeaders"
+name: "setHeaders"
+nameWithType: "Link.setHeaders"
 members:
-- uid: com.microsoft.samples.Link.setHeaders(java.util.Collection<com.microsoft.samples.KeyValuePair<java.lang.String,java.lang.String>>)
-  fullName: com.microsoft.samples.Link.setHeaders(Collection<KeyValuePair<String,String>> value)
-  name: setHeaders(Collection<KeyValuePair<String,String>> value)
-  nameWithType: Link.setHeaders(Collection<KeyValuePair<String,String>> value)
+- uid: "com.microsoft.samples.Link.setHeaders(java.util.Collection<com.microsoft.samples.KeyValuePair<java.lang.String,java.lang.String>>)"
+  fullName: "com.microsoft.samples.Link.setHeaders(Collection<KeyValuePair<String,String>> value)"
+  name: "setHeaders(Collection<KeyValuePair<String,String>> value)"
+  nameWithType: "Link.setHeaders(Collection<KeyValuePair<String,String>> value)"
   parameters:
-  - name: value
-    type: <xref href="java.util.Collection?alt=java.util.Collection&text=Collection" data-throw-if-not-resolved="False" />&lt;<xref href="com.microsoft.samples.KeyValuePair?alt=com.microsoft.samples.KeyValuePair&text=KeyValuePair" data-throw-if-not-resolved="False" />&lt;<xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />,<xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />&gt;&gt;
-  syntax: public void setHeaders(Collection<KeyValuePair<String,String>> value)
-type: method
+  - name: "value"
+    type: "<xref href=\"java.util.Collection?alt=java.util.Collection&text=Collection\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"com.microsoft.samples.KeyValuePair?alt=com.microsoft.samples.KeyValuePair&text=KeyValuePair\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />,<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />&gt;&gt;"
+  syntax: "public void setHeaders(Collection<KeyValuePair<String,String>> value)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Link.setMethod.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Link.setMethod.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.Link.setMethod*
-fullName: com.microsoft.samples.Link.setMethod
-name: setMethod
-nameWithType: Link.setMethod
+uid: "com.microsoft.samples.Link.setMethod*"
+fullName: "com.microsoft.samples.Link.setMethod"
+name: "setMethod"
+nameWithType: "Link.setMethod"
 members:
-- uid: com.microsoft.samples.Link.setMethod(java.lang.String)
-  fullName: com.microsoft.samples.Link.setMethod(String value)
-  name: setMethod(String value)
-  nameWithType: Link.setMethod(String value)
+- uid: "com.microsoft.samples.Link.setMethod(java.lang.String)"
+  fullName: "com.microsoft.samples.Link.setMethod(String value)"
+  name: "setMethod(String value)"
+  nameWithType: "Link.setMethod(String value)"
   parameters:
-  - name: value
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public void setMethod(String value)
-type: method
+  - name: "value"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setMethod(String value)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Link.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Link.yml
@@ -1,30 +1,30 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.Link
-fullName: com.microsoft.samples.Link
-name: Link
-nameWithType: Link
+uid: "com.microsoft.samples.Link"
+fullName: "com.microsoft.samples.Link"
+name: "Link"
+nameWithType: "Link"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class Link
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class Link"
 constructors:
-- com.microsoft.samples.Link.Link()
+- "com.microsoft.samples.Link.Link()"
 methods:
-- com.microsoft.samples.Link.getHeaders()
-- com.microsoft.samples.Link.getMethod()
-- com.microsoft.samples.Link.setHeaders(java.util.Collection<com.microsoft.samples.KeyValuePair<java.lang.String,java.lang.String>>)
-- com.microsoft.samples.Link.setMethod(java.lang.String)
-type: class
+- "com.microsoft.samples.Link.getHeaders()"
+- "com.microsoft.samples.Link.getMethod()"
+- "com.microsoft.samples.Link.setHeaders(java.util.Collection<com.microsoft.samples.KeyValuePair<java.lang.String,java.lang.String>>)"
+- "com.microsoft.samples.Link.setMethod(java.lang.String)"
+type: "class"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Subpackage(class).yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Subpackage(class).yml
@@ -1,25 +1,25 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.Subpackage
-fullName: com.microsoft.samples.Subpackage
-name: Subpackage
-nameWithType: Subpackage
+uid: "com.microsoft.samples.Subpackage"
+fullName: "com.microsoft.samples.Subpackage"
+name: "Subpackage"
+nameWithType: "Subpackage"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class Subpackage
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class Subpackage"
 constructors:
-- com.microsoft.samples.Subpackage.Subpackage()
-type: class
+- "com.microsoft.samples.Subpackage.Subpackage()"
+type: "class"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.Subpackage.Subpackage.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.Subpackage.Subpackage.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.Subpackage.Subpackage*
-fullName: com.microsoft.samples.Subpackage.Subpackage
-name: Subpackage
-nameWithType: Subpackage.Subpackage
+uid: "com.microsoft.samples.Subpackage.Subpackage*"
+fullName: "com.microsoft.samples.Subpackage.Subpackage"
+name: "Subpackage"
+nameWithType: "Subpackage.Subpackage"
 members:
-- uid: com.microsoft.samples.Subpackage.Subpackage()
-  fullName: com.microsoft.samples.Subpackage.Subpackage()
-  name: Subpackage()
-  nameWithType: Subpackage.Subpackage()
-  syntax: public Subpackage()
-type: constructor
+- uid: "com.microsoft.samples.Subpackage.Subpackage()"
+  fullName: "com.microsoft.samples.Subpackage.Subpackage()"
+  name: "Subpackage()"
+  nameWithType: "Subpackage.Subpackage()"
+  syntax: "public Subpackage()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.ReturnNull.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.ReturnNull.yml
@@ -1,0 +1,22 @@
+### YamlMime:JavaMember
+uid: "com.microsoft.samples.SuperHero.ReturnNull*"
+fullName: "com.microsoft.samples.SuperHero.<V>ReturnNull"
+name: "<V>ReturnNull"
+nameWithType: "SuperHero.<V>ReturnNull"
+members:
+- uid: "com.microsoft.samples.SuperHero.<V>ReturnNull(java.lang.Class<V>)"
+  fullName: "com.microsoft.samples.SuperHero.<V>ReturnNull(Class<V> aClass)"
+  name: "<V>ReturnNull(Class<V> aClass)"
+  nameWithType: "SuperHero.<V>ReturnNull(Class<V> aClass)"
+  summary: "Returns a FileStoreAttributeView of the given type.\n <p>\n This method always returns null as no <xref uid=\"FileStoreAttributeView\" data-throw-if-not-resolved=\"false\">FileStoreAttributeView</xref> is currently supported."
+  parameters:
+  - description: "a class"
+    name: "aClass"
+    type: "<xref href=\"java.lang.Class?alt=java.lang.Class&text=Class\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"V?alt=V&text=V\" data-throw-if-not-resolved=\"False\" />&gt;"
+  syntax: "public V <V>ReturnNull(Class<V> aClass)"
+  returns:
+    description: "null"
+    type: "<xref href=\"V?alt=V&text=V\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
+metadata: {}
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING
-fullName: com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING
-name: SOME_PUBLIC_STRING
-nameWithType: SuperHero.SOME_PUBLIC_STRING
+uid: "com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING"
+fullName: "com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING"
+name: "SOME_PUBLIC_STRING"
+nameWithType: "SuperHero.SOME_PUBLIC_STRING"
 members:
-- uid: com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING
-  fullName: com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING
-  name: SOME_PUBLIC_STRING
-  nameWithType: SuperHero.SOME_PUBLIC_STRING
-  syntax: public final String SOME_PUBLIC_STRING
-type: field
+- uid: "com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING"
+  fullName: "com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING"
+  name: "SOME_PUBLIC_STRING"
+  nameWithType: "SuperHero.SOME_PUBLIC_STRING"
+  syntax: "public final String SOME_PUBLIC_STRING"
+type: "field"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.SuperHero.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.SuperHero.yml
@@ -1,28 +1,28 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.SuperHero*
-fullName: com.microsoft.samples.SuperHero.SuperHero
-name: SuperHero
-nameWithType: SuperHero.SuperHero
+uid: "com.microsoft.samples.SuperHero.SuperHero*"
+fullName: "com.microsoft.samples.SuperHero.SuperHero"
+name: "SuperHero"
+nameWithType: "SuperHero.SuperHero"
 members:
-- uid: com.microsoft.samples.SuperHero.SuperHero()
-  fullName: com.microsoft.samples.SuperHero.SuperHero()
-  name: SuperHero()
-  nameWithType: SuperHero.SuperHero()
-  syntax: public SuperHero()
-- uid: com.microsoft.samples.SuperHero.SuperHero(java.lang.String,java.lang.String,int,int)
-  fullName: com.microsoft.samples.SuperHero.SuperHero(String heroName, String uniquePower, int health, int defense)
-  name: SuperHero(String heroName, String uniquePower, int health, int defense)
-  nameWithType: SuperHero.SuperHero(String heroName, String uniquePower, int health, int defense)
+- uid: "com.microsoft.samples.SuperHero.SuperHero()"
+  fullName: "com.microsoft.samples.SuperHero.SuperHero()"
+  name: "SuperHero()"
+  nameWithType: "SuperHero.SuperHero()"
+  syntax: "public SuperHero()"
+- uid: "com.microsoft.samples.SuperHero.SuperHero(java.lang.String,java.lang.String,int,int)"
+  fullName: "com.microsoft.samples.SuperHero.SuperHero(String heroName, String uniquePower, int health, int defense)"
+  name: "SuperHero(String heroName, String uniquePower, int health, int defense)"
+  nameWithType: "SuperHero.SuperHero(String heroName, String uniquePower, int health, int defense)"
   parameters:
-  - name: heroName
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  - name: uniquePower
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  - name: health
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  - name: defense
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  syntax: public SuperHero(String heroName, String uniquePower, int health, int defense)
-type: constructor
+  - name: "heroName"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  - name: "uniquePower"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  - name: "health"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  - name: "defense"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public SuperHero(String heroName, String uniquePower, int health, int defense)"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getDefense.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getDefense.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.getDefense*
-fullName: com.microsoft.samples.SuperHero.getDefense
-name: getDefense
-nameWithType: SuperHero.getDefense
+uid: "com.microsoft.samples.SuperHero.getDefense*"
+fullName: "com.microsoft.samples.SuperHero.getDefense"
+name: "getDefense"
+nameWithType: "SuperHero.getDefense"
 members:
-- uid: com.microsoft.samples.SuperHero.getDefense()
-  fullName: com.microsoft.samples.SuperHero.getDefense()
-  name: getDefense()
-  nameWithType: SuperHero.getDefense()
-  syntax: public int getDefense()
+- uid: "com.microsoft.samples.SuperHero.getDefense()"
+  fullName: "com.microsoft.samples.SuperHero.getDefense()"
+  name: "getDefense()"
+  nameWithType: "SuperHero.getDefense()"
+  syntax: "public int getDefense()"
   returns:
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getHealth.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getHealth.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.getHealth*
-fullName: com.microsoft.samples.SuperHero.getHealth
-name: getHealth
-nameWithType: SuperHero.getHealth
+uid: "com.microsoft.samples.SuperHero.getHealth*"
+fullName: "com.microsoft.samples.SuperHero.getHealth"
+name: "getHealth"
+nameWithType: "SuperHero.getHealth"
 members:
-- uid: com.microsoft.samples.SuperHero.getHealth()
-  fullName: com.microsoft.samples.SuperHero.getHealth()
-  name: getHealth()
-  nameWithType: SuperHero.getHealth()
-  syntax: protected int getHealth()
+- uid: "com.microsoft.samples.SuperHero.getHealth()"
+  fullName: "com.microsoft.samples.SuperHero.getHealth()"
+  name: "getHealth()"
+  nameWithType: "SuperHero.getHealth()"
+  syntax: "protected int getHealth()"
   returns:
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getHeroName.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getHeroName.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.getHeroName*
-fullName: com.microsoft.samples.SuperHero.getHeroName
-name: getHeroName
-nameWithType: SuperHero.getHeroName
+uid: "com.microsoft.samples.SuperHero.getHeroName*"
+fullName: "com.microsoft.samples.SuperHero.getHeroName"
+name: "getHeroName"
+nameWithType: "SuperHero.getHeroName"
 members:
-- uid: com.microsoft.samples.SuperHero.getHeroName()
-  fullName: com.microsoft.samples.SuperHero.getHeroName()
-  name: getHeroName()
-  nameWithType: SuperHero.getHeroName()
-  syntax: public String getHeroName()
+- uid: "com.microsoft.samples.SuperHero.getHeroName()"
+  fullName: "com.microsoft.samples.SuperHero.getHeroName()"
+  name: "getHeroName()"
+  nameWithType: "SuperHero.getHeroName()"
+  syntax: "public String getHeroName()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getLastName.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getLastName.yml
@@ -1,23 +1,19 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.getLastName*
-fullName: com.microsoft.samples.SuperHero.getLastName
-name: getLastName
-nameWithType: SuperHero.getLastName
+uid: "com.microsoft.samples.SuperHero.getLastName*"
+fullName: "com.microsoft.samples.SuperHero.getLastName"
+name: "getLastName"
+nameWithType: "SuperHero.getLastName"
 members:
-- uid: com.microsoft.samples.SuperHero.getLastName()
-  fullName: com.microsoft.samples.SuperHero.getLastName()
-  name: getLastName()
-  nameWithType: SuperHero.getLastName()
-  summary: |-
-    Get capitalized last name. But it's not the end,
-     because of multiline comment
-  overridden: com.microsoft.samples.subpackage.Person.getLastName()
-  syntax: public String getLastName()
+- uid: "com.microsoft.samples.SuperHero.getLastName()"
+  fullName: "com.microsoft.samples.SuperHero.getLastName()"
+  name: "getLastName()"
+  nameWithType: "SuperHero.getLastName()"
+  summary: "Get capitalized last name. But it's not the end,\n because of multiline comment"
+  overridden: "com.microsoft.samples.subpackage.Person.getLastName()"
+  syntax: "public String getLastName()"
   returns:
-    description: |-
-      lastName in uppercase. But it's not the end,
-       because of multiline comment
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    description: "lastName in uppercase. But it's not the end,\n because of multiline comment"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getUniquePower.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.getUniquePower.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.getUniquePower*
-fullName: com.microsoft.samples.SuperHero.getUniquePower
-name: getUniquePower
-nameWithType: SuperHero.getUniquePower
+uid: "com.microsoft.samples.SuperHero.getUniquePower*"
+fullName: "com.microsoft.samples.SuperHero.getUniquePower"
+name: "getUniquePower"
+nameWithType: "SuperHero.getUniquePower"
 members:
-- uid: com.microsoft.samples.SuperHero.getUniquePower()
-  fullName: com.microsoft.samples.SuperHero.getUniquePower()
-  name: getUniquePower()
-  nameWithType: SuperHero.getUniquePower()
-  syntax: public String getUniquePower()
+- uid: "com.microsoft.samples.SuperHero.getUniquePower()"
+  fullName: "com.microsoft.samples.SuperHero.getUniquePower()"
+  name: "getUniquePower()"
+  nameWithType: "SuperHero.getUniquePower()"
+  syntax: "public String getUniquePower()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setDefense.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setDefense.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.setDefense*
-fullName: com.microsoft.samples.SuperHero.setDefense
-name: setDefense
-nameWithType: SuperHero.setDefense
+uid: "com.microsoft.samples.SuperHero.setDefense*"
+fullName: "com.microsoft.samples.SuperHero.setDefense"
+name: "setDefense"
+nameWithType: "SuperHero.setDefense"
 members:
-- uid: com.microsoft.samples.SuperHero.setDefense(int)
-  fullName: com.microsoft.samples.SuperHero.setDefense(int defense)
-  name: setDefense(int defense)
-  nameWithType: SuperHero.setDefense(int defense)
+- uid: "com.microsoft.samples.SuperHero.setDefense(int)"
+  fullName: "com.microsoft.samples.SuperHero.setDefense(int defense)"
+  name: "setDefense(int defense)"
+  nameWithType: "SuperHero.setDefense(int defense)"
   parameters:
-  - name: defense
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  syntax: public void setDefense(int defense)
-type: method
+  - name: "defense"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setDefense(int defense)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setHealth.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setHealth.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.setHealth*
-fullName: com.microsoft.samples.SuperHero.setHealth
-name: setHealth
-nameWithType: SuperHero.setHealth
+uid: "com.microsoft.samples.SuperHero.setHealth*"
+fullName: "com.microsoft.samples.SuperHero.setHealth"
+name: "setHealth"
+nameWithType: "SuperHero.setHealth"
 members:
-- uid: com.microsoft.samples.SuperHero.setHealth(int)
-  fullName: com.microsoft.samples.SuperHero.setHealth(int health)
-  name: setHealth(int health)
-  nameWithType: SuperHero.setHealth(int health)
+- uid: "com.microsoft.samples.SuperHero.setHealth(int)"
+  fullName: "com.microsoft.samples.SuperHero.setHealth(int health)"
+  name: "setHealth(int health)"
+  nameWithType: "SuperHero.setHealth(int health)"
   parameters:
-  - name: health
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  syntax: protected void setHealth(int health)
-type: method
+  - name: "health"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "protected void setHealth(int health)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setHeroName.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setHeroName.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.setHeroName*
-fullName: com.microsoft.samples.SuperHero.setHeroName
-name: setHeroName
-nameWithType: SuperHero.setHeroName
+uid: "com.microsoft.samples.SuperHero.setHeroName*"
+fullName: "com.microsoft.samples.SuperHero.setHeroName"
+name: "setHeroName"
+nameWithType: "SuperHero.setHeroName"
 members:
-- uid: com.microsoft.samples.SuperHero.setHeroName(java.lang.String)
-  fullName: com.microsoft.samples.SuperHero.setHeroName(String heroName)
-  name: setHeroName(String heroName)
-  nameWithType: SuperHero.setHeroName(String heroName)
+- uid: "com.microsoft.samples.SuperHero.setHeroName(java.lang.String)"
+  fullName: "com.microsoft.samples.SuperHero.setHeroName(String heroName)"
+  name: "setHeroName(String heroName)"
+  nameWithType: "SuperHero.setHeroName(String heroName)"
   parameters:
-  - name: heroName
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public void setHeroName(String heroName)
-type: method
+  - name: "heroName"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setHeroName(String heroName)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setUniquePower.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.setUniquePower.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.setUniquePower*
-fullName: com.microsoft.samples.SuperHero.setUniquePower
-name: setUniquePower
-nameWithType: SuperHero.setUniquePower
+uid: "com.microsoft.samples.SuperHero.setUniquePower*"
+fullName: "com.microsoft.samples.SuperHero.setUniquePower"
+name: "setUniquePower"
+nameWithType: "SuperHero.setUniquePower"
 members:
-- uid: com.microsoft.samples.SuperHero.setUniquePower(java.lang.String)
-  fullName: com.microsoft.samples.SuperHero.setUniquePower(String uniquePower)
-  name: setUniquePower(String uniquePower)
-  nameWithType: SuperHero.setUniquePower(String uniquePower)
+- uid: "com.microsoft.samples.SuperHero.setUniquePower(java.lang.String)"
+  fullName: "com.microsoft.samples.SuperHero.setUniquePower(String uniquePower)"
+  name: "setUniquePower(String uniquePower)"
+  nameWithType: "SuperHero.setUniquePower(String uniquePower)"
   parameters:
-  - name: uniquePower
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public void setUniquePower(String uniquePower)
-type: method
+  - name: "uniquePower"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setUniquePower(String uniquePower)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.successfullyAttacked.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.successfullyAttacked.yml
@@ -1,31 +1,28 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.SuperHero.successfullyAttacked*
-fullName: com.microsoft.samples.SuperHero.successfullyAttacked
-name: successfullyAttacked
-nameWithType: SuperHero.successfullyAttacked
+uid: "com.microsoft.samples.SuperHero.successfullyAttacked*"
+fullName: "com.microsoft.samples.SuperHero.successfullyAttacked"
+name: "successfullyAttacked"
+nameWithType: "SuperHero.successfullyAttacked"
 members:
-- uid: com.microsoft.samples.SuperHero.successfullyAttacked(int,java.lang.String)
-  fullName: com.microsoft.samples.SuperHero.successfullyAttacked(int incomingDamage, String damageType)
-  name: successfullyAttacked(int incomingDamage, String damageType)
-  nameWithType: SuperHero.successfullyAttacked(int incomingDamage, String damageType)
-  summary: |-
-    <p>This is a simple description of the method. . .
-     <a href="http://www.supermanisthegreatest.com">Superman!</a>
-     </p>
+- uid: "com.microsoft.samples.SuperHero.successfullyAttacked(int,java.lang.String)"
+  fullName: "com.microsoft.samples.SuperHero.successfullyAttacked(int incomingDamage, String damageType)"
+  name: "successfullyAttacked(int incomingDamage, String damageType)"
+  nameWithType: "SuperHero.successfullyAttacked(int incomingDamage, String damageType)"
+  summary: "<p>This is a simple description of the method. . .\n <a href=\"http://www.supermanisthegreatest.com\">Superman!</a>\n </p>"
   parameters:
-  - description: the amount of incoming damage for <xref uid="com.microsoft.samples.SuperHero" data-throw-if-not-resolved="false">SuperHero</xref>
-    name: incomingDamage
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  - description: type of damage with similar word damageTypeLong, sure
-    name: damageType
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public int successfullyAttacked(int incomingDamage, String damageType)
+  - description: "the amount of incoming damage for <xref uid=\"com.microsoft.samples.SuperHero\" data-throw-if-not-resolved=\"false\">SuperHero</xref>"
+    name: "incomingDamage"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  - description: "type of damage with similar word damageTypeLong, sure"
+    name: "damageType"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public int successfullyAttacked(int incomingDamage, String damageType)"
   exceptions:
-  - description: when incomingDamage is negative and thanks for <xref uid="Exception" data-throw-if-not-resolved="false">Exception</xref>
-    type: <xref href="java.lang.IllegalArgumentException?alt=java.lang.IllegalArgumentException&text=IllegalArgumentException" data-throw-if-not-resolved="False" />
+  - description: "when incomingDamage is negative and thanks for <xref uid=\"Exception\" data-throw-if-not-resolved=\"false\">Exception</xref>"
+    type: "<xref href=\"java.lang.IllegalArgumentException?alt=java.lang.IllegalArgumentException&text=IllegalArgumentException\" data-throw-if-not-resolved=\"False\" />"
   returns:
-    description: the amount of health hero has after attack
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-type: method
+    description: "the amount of health hero has after attack"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.SuperHero.yml
@@ -1,51 +1,52 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.SuperHero
-fullName: com.microsoft.samples.SuperHero
-name: SuperHero
-nameWithType: SuperHero
-summary: Hero is the main entity we will be using to something
+uid: "com.microsoft.samples.SuperHero"
+fullName: "com.microsoft.samples.SuperHero"
+name: "SuperHero"
+nameWithType: "SuperHero"
+summary: "Hero is the main entity we will be using to something"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.subpackage.Person" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.subpackage.Person\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- com.microsoft.samples.subpackage.Person.buildPerson(com.microsoft.samples.subpackage.Person)
-- com.microsoft.samples.subpackage.Person.getFirstName()
-- com.microsoft.samples.subpackage.Person.getLastName()
-- com.microsoft.samples.subpackage.Person.getSomeSet()
-- com.microsoft.samples.subpackage.Person.setFirstName(java.lang.String)
-- com.microsoft.samples.subpackage.Person.setLastName()
-- com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class SuperHero extends Person implements Serializable, Cloneable
+- "com.microsoft.samples.subpackage.Person.buildPerson(com.microsoft.samples.subpackage.Person)"
+- "com.microsoft.samples.subpackage.Person.getFirstName()"
+- "com.microsoft.samples.subpackage.Person.getLastName()"
+- "com.microsoft.samples.subpackage.Person.getSomeSet()"
+- "com.microsoft.samples.subpackage.Person.setFirstName(java.lang.String)"
+- "com.microsoft.samples.subpackage.Person.setLastName()"
+- "com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)"
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class SuperHero extends Person implements Serializable, Cloneable"
 constructors:
-- com.microsoft.samples.SuperHero.SuperHero()
-- com.microsoft.samples.SuperHero.SuperHero(java.lang.String,java.lang.String,int,int)
+- "com.microsoft.samples.SuperHero.SuperHero()"
+- "com.microsoft.samples.SuperHero.SuperHero(java.lang.String,java.lang.String,int,int)"
 fields:
-- com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING
+- "com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING"
 methods:
-- com.microsoft.samples.SuperHero.getDefense()
-- com.microsoft.samples.SuperHero.getHealth()
-- com.microsoft.samples.SuperHero.getHeroName()
-- com.microsoft.samples.SuperHero.getLastName()
-- com.microsoft.samples.SuperHero.getUniquePower()
-- com.microsoft.samples.SuperHero.setDefense(int)
-- com.microsoft.samples.SuperHero.setHealth(int)
-- com.microsoft.samples.SuperHero.setHeroName(java.lang.String)
-- com.microsoft.samples.SuperHero.setUniquePower(java.lang.String)
-- com.microsoft.samples.SuperHero.successfullyAttacked(int,java.lang.String)
-type: class
+- "com.microsoft.samples.SuperHero.<V>ReturnNull(java.lang.Class<V>)"
+- "com.microsoft.samples.SuperHero.getDefense()"
+- "com.microsoft.samples.SuperHero.getHealth()"
+- "com.microsoft.samples.SuperHero.getHeroName()"
+- "com.microsoft.samples.SuperHero.getLastName()"
+- "com.microsoft.samples.SuperHero.getUniquePower()"
+- "com.microsoft.samples.SuperHero.setDefense(int)"
+- "com.microsoft.samples.SuperHero.setHealth(int)"
+- "com.microsoft.samples.SuperHero.setHeroName(java.lang.String)"
+- "com.microsoft.samples.SuperHero.setUniquePower(java.lang.String)"
+- "com.microsoft.samples.SuperHero.successfullyAttacked(int,java.lang.String)"
+type: "class"
 implements:
-- <xref href="java.io.Serializable?alt=java.io.Serializable&text=Serializable" data-throw-if-not-resolved="False" />
-- <xref href="java.lang.Cloneable?alt=java.lang.Cloneable&text=Cloneable" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.io.Serializable?alt=java.io.Serializable&text=Serializable\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"java.lang.Cloneable?alt=java.lang.Cloneable&text=Cloneable\" data-throw-if-not-resolved=\"False\" />"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations.yml
@@ -1,19 +1,19 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations*
-fullName: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations
-name: AgreementDetailsCollectionOperations
-nameWithType: AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations
+uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations*"
+fullName: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations"
+name: "AgreementDetailsCollectionOperations"
+nameWithType: "AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations"
 members:
-- uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(com.microsoft.samples.IPartner)
-  fullName: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)
-  name: AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)
-  nameWithType: AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)
-  summary: Initializes a new instance of the AgreementDetailsCollectionOperations class.
+- uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(com.microsoft.samples.IPartner)"
+  fullName: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)"
+  name: "AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)"
+  nameWithType: "AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)"
+  summary: "Initializes a new instance of the AgreementDetailsCollectionOperations class."
   parameters:
-  - description: The root partner operations instance.
-    name: rootPartnerOperations
-    type: <xref href="com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner" data-throw-if-not-resolved="False" />
-  syntax: public AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)
-type: constructor
+  - description: "The root partner operations instance."
+    name: "rootPartnerOperations"
+    type: "<xref href=\"com.microsoft.samples.IPartner?alt=com.microsoft.samples.IPartner&text=IPartner\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public AgreementDetailsCollectionOperations(IPartner rootPartnerOperations)"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get.yml
@@ -1,28 +1,28 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get*
-fullName: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get
-name: get
-nameWithType: AgreementDetailsCollectionOperations.get
+uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get*"
+fullName: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get"
+name: "get"
+nameWithType: "AgreementDetailsCollectionOperations.get"
 members:
-- uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get()
-  fullName: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get()
-  name: get()
-  nameWithType: AgreementDetailsCollectionOperations.get()
-  summary: Retrieves the agreement details.
-  syntax: public ResourceCollection<AgreementMetaData> get()
+- uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get()"
+  fullName: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get()"
+  name: "get()"
+  nameWithType: "AgreementDetailsCollectionOperations.get()"
+  summary: "Retrieves the agreement details."
+  syntax: "public ResourceCollection<AgreementMetaData> get()"
   returns:
-    description: A list of agreement details.
-    type: <xref href="com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection" data-throw-if-not-resolved="False" />&lt;<xref href="com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData" data-throw-if-not-resolved="False" />&gt;
-- uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get(java.lang.String)
-  fullName: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get(String id)
-  name: get(String id)
-  nameWithType: AgreementDetailsCollectionOperations.get(String id)
+    description: "A list of agreement details."
+    type: "<xref href=\"com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData\" data-throw-if-not-resolved=\"False\" />&gt;"
+- uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get(java.lang.String)"
+  fullName: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get(String id)"
+  name: "get(String id)"
+  nameWithType: "AgreementDetailsCollectionOperations.get(String id)"
   parameters:
-  - name: id
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public ResourceCollection<AgreementMetaData> get(String id)
+  - name: "id"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public ResourceCollection<AgreementMetaData> get(String id)"
   returns:
-    type: <xref href="com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection" data-throw-if-not-resolved="False" />&lt;<xref href="com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData" data-throw-if-not-resolved="False" />&gt;
-type: method
+    type: "<xref href=\"com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData\" data-throw-if-not-resolved=\"False\" />&gt;"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.yml
@@ -1,35 +1,35 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations
-fullName: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations
-name: AgreementDetailsCollectionOperations
-nameWithType: AgreementDetailsCollectionOperations
-summary: Agreement details collection operations implementation class.
+uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations"
+fullName: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations"
+name: "AgreementDetailsCollectionOperations"
+nameWithType: "AgreementDetailsCollectionOperations"
+summary: "Agreement details collection operations implementation class."
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.BasePartnerComponent" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.BasePartnerComponentString" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.BasePartnerComponent\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.BasePartnerComponentString\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- com.microsoft.samples.BasePartnerComponent.testBase()
-- com.microsoft.samples.BasePartnerComponentString.testInherited()
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class AgreementDetailsCollectionOperations extends BasePartnerComponentString implements IAgreementDetailsCollection
+- "com.microsoft.samples.BasePartnerComponent.testBase()"
+- "com.microsoft.samples.BasePartnerComponentString.testInherited()"
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class AgreementDetailsCollectionOperations extends BasePartnerComponentString implements IAgreementDetailsCollection"
 constructors:
-- com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(com.microsoft.samples.IPartner)
+- "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations(com.microsoft.samples.IPartner)"
 methods:
-- com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get()
-- com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get(java.lang.String)
-type: class
+- "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get()"
+- "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get(java.lang.String)"
+type: "class"
 implements:
-- <xref href="com.microsoft.samples.agreements.IAgreementDetailsCollection?alt=com.microsoft.samples.agreements.IAgreementDetailsCollection&text=IAgreementDetailsCollection" data-throw-if-not-resolved="False" />
+- "<xref href=\"com.microsoft.samples.agreements.IAgreementDetailsCollection?alt=com.microsoft.samples.agreements.IAgreementDetailsCollection&text=IAgreementDetailsCollection\" data-throw-if-not-resolved=\"False\" />"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData*
-fullName: com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData
-name: AgreementMetaData
-nameWithType: AgreementMetaData.AgreementMetaData
+uid: "com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData*"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData"
+name: "AgreementMetaData"
+nameWithType: "AgreementMetaData.AgreementMetaData"
 members:
-- uid: com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData()
-  fullName: com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData()
-  name: AgreementMetaData()
-  nameWithType: AgreementMetaData.AgreementMetaData()
-  syntax: public AgreementMetaData()
-type: constructor
+- uid: "com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData()"
+  fullName: "com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData()"
+  name: "AgreementMetaData()"
+  nameWithType: "AgreementMetaData.AgreementMetaData()"
+  syntax: "public AgreementMetaData()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink*
-fullName: com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink
-name: getAgreementLink
-nameWithType: AgreementMetaData.getAgreementLink
+uid: "com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink*"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink"
+name: "getAgreementLink"
+nameWithType: "AgreementMetaData.getAgreementLink"
 members:
-- uid: com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink()
-  fullName: com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink()
-  name: getAgreementLink()
-  nameWithType: AgreementMetaData.getAgreementLink()
-  syntax: public String getAgreementLink()
+- uid: "com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink()"
+  fullName: "com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink()"
+  name: "getAgreementLink()"
+  nameWithType: "AgreementMetaData.getAgreementLink()"
+  syntax: "public String getAgreementLink()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.getTemplateId.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.getTemplateId.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementMetaData.getTemplateId*
-fullName: com.microsoft.samples.agreements.AgreementMetaData.getTemplateId
-name: getTemplateId
-nameWithType: AgreementMetaData.getTemplateId
+uid: "com.microsoft.samples.agreements.AgreementMetaData.getTemplateId*"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData.getTemplateId"
+name: "getTemplateId"
+nameWithType: "AgreementMetaData.getTemplateId"
 members:
-- uid: com.microsoft.samples.agreements.AgreementMetaData.getTemplateId()
-  fullName: com.microsoft.samples.agreements.AgreementMetaData.getTemplateId()
-  name: getTemplateId()
-  nameWithType: AgreementMetaData.getTemplateId()
-  syntax: public String getTemplateId()
+- uid: "com.microsoft.samples.agreements.AgreementMetaData.getTemplateId()"
+  fullName: "com.microsoft.samples.agreements.AgreementMetaData.getTemplateId()"
+  name: "getTemplateId()"
+  nameWithType: "AgreementMetaData.getTemplateId()"
+  syntax: "public String getTemplateId()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.getVersionRank.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.getVersionRank.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementMetaData.getVersionRank*
-fullName: com.microsoft.samples.agreements.AgreementMetaData.getVersionRank
-name: getVersionRank
-nameWithType: AgreementMetaData.getVersionRank
+uid: "com.microsoft.samples.agreements.AgreementMetaData.getVersionRank*"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData.getVersionRank"
+name: "getVersionRank"
+nameWithType: "AgreementMetaData.getVersionRank"
 members:
-- uid: com.microsoft.samples.agreements.AgreementMetaData.getVersionRank()
-  fullName: com.microsoft.samples.agreements.AgreementMetaData.getVersionRank()
-  name: getVersionRank()
-  nameWithType: AgreementMetaData.getVersionRank()
-  syntax: public int getVersionRank()
+- uid: "com.microsoft.samples.agreements.AgreementMetaData.getVersionRank()"
+  fullName: "com.microsoft.samples.agreements.AgreementMetaData.getVersionRank()"
+  name: "getVersionRank()"
+  nameWithType: "AgreementMetaData.getVersionRank()"
+  syntax: "public int getVersionRank()"
   returns:
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink*
-fullName: com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink
-name: setAgreementLink
-nameWithType: AgreementMetaData.setAgreementLink
+uid: "com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink*"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink"
+name: "setAgreementLink"
+nameWithType: "AgreementMetaData.setAgreementLink"
 members:
-- uid: com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink(java.lang.String)
-  fullName: com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink(String value)
-  name: setAgreementLink(String value)
-  nameWithType: AgreementMetaData.setAgreementLink(String value)
+- uid: "com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink(java.lang.String)"
+  fullName: "com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink(String value)"
+  name: "setAgreementLink(String value)"
+  nameWithType: "AgreementMetaData.setAgreementLink(String value)"
   parameters:
-  - name: value
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public void setAgreementLink(String value)
-type: method
+  - name: "value"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setAgreementLink(String value)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.setTemplateId.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.setTemplateId.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementMetaData.setTemplateId*
-fullName: com.microsoft.samples.agreements.AgreementMetaData.setTemplateId
-name: setTemplateId
-nameWithType: AgreementMetaData.setTemplateId
+uid: "com.microsoft.samples.agreements.AgreementMetaData.setTemplateId*"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData.setTemplateId"
+name: "setTemplateId"
+nameWithType: "AgreementMetaData.setTemplateId"
 members:
-- uid: com.microsoft.samples.agreements.AgreementMetaData.setTemplateId(java.lang.String)
-  fullName: com.microsoft.samples.agreements.AgreementMetaData.setTemplateId(String value)
-  name: setTemplateId(String value)
-  nameWithType: AgreementMetaData.setTemplateId(String value)
+- uid: "com.microsoft.samples.agreements.AgreementMetaData.setTemplateId(java.lang.String)"
+  fullName: "com.microsoft.samples.agreements.AgreementMetaData.setTemplateId(String value)"
+  name: "setTemplateId(String value)"
+  nameWithType: "AgreementMetaData.setTemplateId(String value)"
   parameters:
-  - name: value
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public void setTemplateId(String value)
-type: method
+  - name: "value"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setTemplateId(String value)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.setVersionRank.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.setVersionRank.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.AgreementMetaData.setVersionRank*
-fullName: com.microsoft.samples.agreements.AgreementMetaData.setVersionRank
-name: setVersionRank
-nameWithType: AgreementMetaData.setVersionRank
+uid: "com.microsoft.samples.agreements.AgreementMetaData.setVersionRank*"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData.setVersionRank"
+name: "setVersionRank"
+nameWithType: "AgreementMetaData.setVersionRank"
 members:
-- uid: com.microsoft.samples.agreements.AgreementMetaData.setVersionRank(int)
-  fullName: com.microsoft.samples.agreements.AgreementMetaData.setVersionRank(int value)
-  name: setVersionRank(int value)
-  nameWithType: AgreementMetaData.setVersionRank(int value)
+- uid: "com.microsoft.samples.agreements.AgreementMetaData.setVersionRank(int)"
+  fullName: "com.microsoft.samples.agreements.AgreementMetaData.setVersionRank(int value)"
+  name: "setVersionRank(int value)"
+  nameWithType: "AgreementMetaData.setVersionRank(int value)"
   parameters:
-  - name: value
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  syntax: public void setVersionRank(int value)
-type: method
+  - name: "value"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setVersionRank(int value)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.AgreementMetaData.yml
@@ -1,33 +1,33 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.agreements.AgreementMetaData
-fullName: com.microsoft.samples.agreements.AgreementMetaData
-name: AgreementMetaData
-nameWithType: AgreementMetaData
-summary: The AgreementMetaData provides metadata about the agreement type that partner can provide confirmation of customer acceptance.
+uid: "com.microsoft.samples.agreements.AgreementMetaData"
+fullName: "com.microsoft.samples.agreements.AgreementMetaData"
+name: "AgreementMetaData"
+nameWithType: "AgreementMetaData"
+summary: "The AgreementMetaData provides metadata about the agreement type that partner can provide confirmation of customer acceptance."
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class AgreementMetaData
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class AgreementMetaData"
 constructors:
-- com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData()
+- "com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData()"
 methods:
-- com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink()
-- com.microsoft.samples.agreements.AgreementMetaData.getTemplateId()
-- com.microsoft.samples.agreements.AgreementMetaData.getVersionRank()
-- com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink(java.lang.String)
-- com.microsoft.samples.agreements.AgreementMetaData.setTemplateId(java.lang.String)
-- com.microsoft.samples.agreements.AgreementMetaData.setVersionRank(int)
-type: class
+- "com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink()"
+- "com.microsoft.samples.agreements.AgreementMetaData.getTemplateId()"
+- "com.microsoft.samples.agreements.AgreementMetaData.getVersionRank()"
+- "com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink(java.lang.String)"
+- "com.microsoft.samples.agreements.AgreementMetaData.setTemplateId(java.lang.String)"
+- "com.microsoft.samples.agreements.AgreementMetaData.setVersionRank(int)"
+type: "class"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.IAgreementDetailsCollection.get.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.IAgreementDetailsCollection.get.yml
@@ -1,28 +1,28 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.IAgreementDetailsCollection.get*
-fullName: com.microsoft.samples.agreements.IAgreementDetailsCollection.get
-name: get
-nameWithType: IAgreementDetailsCollection.get
+uid: "com.microsoft.samples.agreements.IAgreementDetailsCollection.get*"
+fullName: "com.microsoft.samples.agreements.IAgreementDetailsCollection.get"
+name: "get"
+nameWithType: "IAgreementDetailsCollection.get"
 members:
-- uid: com.microsoft.samples.agreements.IAgreementDetailsCollection.get()
-  fullName: com.microsoft.samples.agreements.IAgreementDetailsCollection.get()
-  name: get()
-  nameWithType: IAgreementDetailsCollection.get()
-  summary: Retrieves all current agreement metadata.
-  syntax: public abstract ResourceCollection<AgreementMetaData> get()
+- uid: "com.microsoft.samples.agreements.IAgreementDetailsCollection.get()"
+  fullName: "com.microsoft.samples.agreements.IAgreementDetailsCollection.get()"
+  name: "get()"
+  nameWithType: "IAgreementDetailsCollection.get()"
+  summary: "Retrieves all current agreement metadata."
+  syntax: "public abstract ResourceCollection<AgreementMetaData> get()"
   returns:
-    description: The current agreement metadata.
-    type: <xref href="com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection" data-throw-if-not-resolved="False" />&lt;<xref href="com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData" data-throw-if-not-resolved="False" />&gt;
-- uid: com.microsoft.samples.agreements.IAgreementDetailsCollection.get(java.lang.String)
-  fullName: com.microsoft.samples.agreements.IAgreementDetailsCollection.get(String id)
-  name: get(String id)
-  nameWithType: IAgreementDetailsCollection.get(String id)
+    description: "The current agreement metadata."
+    type: "<xref href=\"com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData\" data-throw-if-not-resolved=\"False\" />&gt;"
+- uid: "com.microsoft.samples.agreements.IAgreementDetailsCollection.get(java.lang.String)"
+  fullName: "com.microsoft.samples.agreements.IAgreementDetailsCollection.get(String id)"
+  name: "get(String id)"
+  nameWithType: "IAgreementDetailsCollection.get(String id)"
   parameters:
-  - name: id
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public abstract ResourceCollection<AgreementMetaData> get(String id)
+  - name: "id"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public abstract ResourceCollection<AgreementMetaData> get(String id)"
   returns:
-    type: <xref href="com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection" data-throw-if-not-resolved="False" />&lt;<xref href="com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData" data-throw-if-not-resolved="False" />&gt;
-type: method
+    type: "<xref href=\"com.microsoft.samples.agreements.ResourceCollection?alt=com.microsoft.samples.agreements.ResourceCollection&text=ResourceCollection\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"com.microsoft.samples.agreements.AgreementMetaData?alt=com.microsoft.samples.agreements.AgreementMetaData&text=AgreementMetaData\" data-throw-if-not-resolved=\"False\" />&gt;"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.IAgreementDetailsCollection.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.IAgreementDetailsCollection.yml
@@ -1,13 +1,13 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.agreements.IAgreementDetailsCollection
-fullName: com.microsoft.samples.agreements.IAgreementDetailsCollection
-name: IAgreementDetailsCollection
-nameWithType: IAgreementDetailsCollection
-summary: Encapsulates the operations on the agreement metadata collection.
-syntax: public interface IAgreementDetailsCollection
+uid: "com.microsoft.samples.agreements.IAgreementDetailsCollection"
+fullName: "com.microsoft.samples.agreements.IAgreementDetailsCollection"
+name: "IAgreementDetailsCollection"
+nameWithType: "IAgreementDetailsCollection"
+summary: "Encapsulates the operations on the agreement metadata collection."
+syntax: "public interface IAgreementDetailsCollection"
 methods:
-- com.microsoft.samples.agreements.IAgreementDetailsCollection.get()
-- com.microsoft.samples.agreements.IAgreementDetailsCollection.get(java.lang.String)
-type: interface
+- "com.microsoft.samples.agreements.IAgreementDetailsCollection.get()"
+- "com.microsoft.samples.agreements.IAgreementDetailsCollection.get(java.lang.String)"
+type: "interface"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.ResourceCollection.ResourceCollection.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.ResourceCollection.ResourceCollection.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.agreements.ResourceCollection.ResourceCollection*
-fullName: com.microsoft.samples.agreements.ResourceCollection<TResource>.ResourceCollection
-name: ResourceCollection
-nameWithType: ResourceCollection<TResource>.ResourceCollection
+uid: "com.microsoft.samples.agreements.ResourceCollection.ResourceCollection*"
+fullName: "com.microsoft.samples.agreements.ResourceCollection<TResource>.ResourceCollection"
+name: "ResourceCollection"
+nameWithType: "ResourceCollection<TResource>.ResourceCollection"
 members:
-- uid: com.microsoft.samples.agreements.ResourceCollection.ResourceCollection()
-  fullName: com.microsoft.samples.agreements.ResourceCollection<TResource>.ResourceCollection()
-  name: ResourceCollection()
-  nameWithType: ResourceCollection<TResource>.ResourceCollection()
-  syntax: public ResourceCollection()
-type: constructor
+- uid: "com.microsoft.samples.agreements.ResourceCollection.ResourceCollection()"
+  fullName: "com.microsoft.samples.agreements.ResourceCollection<TResource>.ResourceCollection()"
+  name: "ResourceCollection()"
+  nameWithType: "ResourceCollection<TResource>.ResourceCollection()"
+  syntax: "public ResourceCollection()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.ResourceCollection.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.ResourceCollection.yml
@@ -1,28 +1,28 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.agreements.ResourceCollection
-fullName: com.microsoft.samples.agreements.ResourceCollection<TResource>
-name: ResourceCollection<TResource>
-nameWithType: ResourceCollection<TResource>
-summary: Contains a collection of resources with JSON properties to represent the output Type of objects in collection
+uid: "com.microsoft.samples.agreements.ResourceCollection"
+fullName: "com.microsoft.samples.agreements.ResourceCollection<TResource>"
+name: "ResourceCollection<TResource>"
+nameWithType: "ResourceCollection<TResource>"
+summary: "Contains a collection of resources with JSON properties to represent the output Type of objects in collection"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class ResourceCollection<TResource>
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class ResourceCollection<TResource>"
 constructors:
-- com.microsoft.samples.agreements.ResourceCollection.ResourceCollection()
-type: class
+- "com.microsoft.samples.agreements.ResourceCollection.ResourceCollection()"
+type: "class"
 typeParameters:
-- name: TResource
+- name: "TResource"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.yml
@@ -1,12 +1,12 @@
 ### YamlMime:JavaPackage
-uid: com.microsoft.samples.agreements
-fullName: com.microsoft.samples.agreements
-name: com.microsoft.samples.agreements
+uid: "com.microsoft.samples.agreements"
+fullName: "com.microsoft.samples.agreements"
+name: "com.microsoft.samples.agreements"
 classes:
-- com.microsoft.samples.agreements.AgreementDetailsCollectionOperations
-- com.microsoft.samples.agreements.AgreementMetaData
-- com.microsoft.samples.agreements.ResourceCollection
+- "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations"
+- "com.microsoft.samples.agreements.AgreementMetaData"
+- "com.microsoft.samples.agreements.ResourceCollection"
 interfaces:
-- com.microsoft.samples.agreements.IAgreementDetailsCollection
+- "com.microsoft.samples.agreements.IAgreementDetailsCollection"
 metadata: {}
-package: com.microsoft.samples.agreements
+package: "com.microsoft.samples.agreements"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.Animal.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.Animal.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Animal.Animal*
-fullName: com.microsoft.samples.commentinheritance.Animal.Animal
-name: Animal
-nameWithType: Animal.Animal
+uid: "com.microsoft.samples.commentinheritance.Animal.Animal*"
+fullName: "com.microsoft.samples.commentinheritance.Animal.Animal"
+name: "Animal"
+nameWithType: "Animal.Animal"
 members:
-- uid: com.microsoft.samples.commentinheritance.Animal.Animal()
-  fullName: com.microsoft.samples.commentinheritance.Animal.Animal()
-  name: Animal()
-  nameWithType: Animal.Animal()
-  syntax: public Animal()
-type: constructor
+- uid: "com.microsoft.samples.commentinheritance.Animal.Animal()"
+  fullName: "com.microsoft.samples.commentinheritance.Animal.Animal()"
+  name: "Animal()"
+  nameWithType: "Animal.Animal()"
+  syntax: "public Animal()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.breathe.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.breathe.yml
@@ -1,15 +1,15 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Animal.breathe*
-fullName: com.microsoft.samples.commentinheritance.Animal.breathe
-name: breathe
-nameWithType: Animal.breathe
+uid: "com.microsoft.samples.commentinheritance.Animal.breathe*"
+fullName: "com.microsoft.samples.commentinheritance.Animal.breathe"
+name: "breathe"
+nameWithType: "Animal.breathe"
 members:
-- uid: com.microsoft.samples.commentinheritance.Animal.breathe()
-  fullName: com.microsoft.samples.commentinheritance.Animal.breathe()
-  name: breathe()
-  nameWithType: Animal.breathe()
-  summary: Breathe.
-  syntax: public void breathe()
-type: method
+- uid: "com.microsoft.samples.commentinheritance.Animal.breathe()"
+  fullName: "com.microsoft.samples.commentinheritance.Animal.breathe()"
+  name: "breathe()"
+  nameWithType: "Animal.breathe()"
+  summary: "Breathe."
+  syntax: "public void breathe()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.feed.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.feed.yml
@@ -1,15 +1,15 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Animal.feed*
-fullName: com.microsoft.samples.commentinheritance.Animal.feed
-name: feed
-nameWithType: Animal.feed
+uid: "com.microsoft.samples.commentinheritance.Animal.feed*"
+fullName: "com.microsoft.samples.commentinheritance.Animal.feed"
+name: "feed"
+nameWithType: "Animal.feed"
 members:
-- uid: com.microsoft.samples.commentinheritance.Animal.feed()
-  fullName: com.microsoft.samples.commentinheritance.Animal.feed()
-  name: feed()
-  nameWithType: Animal.feed()
-  summary: Feed offspring.
-  syntax: public abstract void feed()
-type: method
+- uid: "com.microsoft.samples.commentinheritance.Animal.feed()"
+  fullName: "com.microsoft.samples.commentinheritance.Animal.feed()"
+  name: "feed()"
+  nameWithType: "Animal.feed()"
+  summary: "Feed offspring."
+  syntax: "public abstract void feed()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.getKind.yml
@@ -1,19 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Animal.getKind*
-fullName: com.microsoft.samples.commentinheritance.Animal.getKind
-name: getKind
-nameWithType: Animal.getKind
+uid: "com.microsoft.samples.commentinheritance.Animal.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Animal.getKind"
+name: "getKind"
+nameWithType: "Animal.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Animal.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Animal.getKind()
-  name: getKind()
-  nameWithType: Animal.getKind()
-  summary: |-
-    Get kind from Organism.
-     Get kind from Animal.
-  syntax: public abstract String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Animal.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Animal.getKind()"
+  name: "getKind()"
+  nameWithType: "Animal.getKind()"
+  summary: "Get kind from Organism.\n Get kind from Animal."
+  syntax: "public abstract String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.verballyCommunicate.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.verballyCommunicate.yml
@@ -1,15 +1,15 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Animal.verballyCommunicate*
-fullName: com.microsoft.samples.commentinheritance.Animal.verballyCommunicate
-name: verballyCommunicate
-nameWithType: Animal.verballyCommunicate
+uid: "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate*"
+fullName: "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate"
+name: "verballyCommunicate"
+nameWithType: "Animal.verballyCommunicate"
 members:
-- uid: com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()
-  fullName: com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()
-  name: verballyCommunicate()
-  nameWithType: Animal.verballyCommunicate()
-  summary: Communicate verbally.
-  syntax: public abstract void verballyCommunicate()
-type: method
+- uid: "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()"
+  fullName: "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()"
+  name: "verballyCommunicate()"
+  nameWithType: "Animal.verballyCommunicate()"
+  summary: "Communicate verbally."
+  syntax: "public abstract void verballyCommunicate()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Animal.yml
@@ -1,33 +1,33 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Animal
-fullName: com.microsoft.samples.commentinheritance.Animal
-name: Animal
-nameWithType: Animal
-summary: Animal.
+uid: "com.microsoft.samples.commentinheritance.Animal"
+fullName: "com.microsoft.samples.commentinheritance.Animal"
+name: "Animal"
+nameWithType: "Animal"
+summary: "Animal."
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public abstract class Animal implements Organism
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public abstract class Animal implements Organism"
 constructors:
-- com.microsoft.samples.commentinheritance.Animal.Animal()
+- "com.microsoft.samples.commentinheritance.Animal.Animal()"
 methods:
-- com.microsoft.samples.commentinheritance.Animal.breathe()
-- com.microsoft.samples.commentinheritance.Animal.feed()
-- com.microsoft.samples.commentinheritance.Animal.getKind()
-- com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()
-type: class
+- "com.microsoft.samples.commentinheritance.Animal.breathe()"
+- "com.microsoft.samples.commentinheritance.Animal.feed()"
+- "com.microsoft.samples.commentinheritance.Animal.getKind()"
+- "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()"
+type: "class"
 implements:
-- <xref href="com.microsoft.samples.commentinheritance.Organism?alt=com.microsoft.samples.commentinheritance.Organism&text=Organism" data-throw-if-not-resolved="False" />
+- "<xref href=\"com.microsoft.samples.commentinheritance.Organism?alt=com.microsoft.samples.commentinheritance.Organism&text=Organism\" data-throw-if-not-resolved=\"False\" />"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Carnivorous.eat.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Carnivorous.eat.yml
@@ -1,19 +1,19 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Carnivorous.eat*
-fullName: com.microsoft.samples.commentinheritance.Carnivorous.eat
-name: eat
-nameWithType: Carnivorous.eat
+uid: "com.microsoft.samples.commentinheritance.Carnivorous.eat*"
+fullName: "com.microsoft.samples.commentinheritance.Carnivorous.eat"
+name: "eat"
+nameWithType: "Carnivorous.eat"
 members:
-- uid: com.microsoft.samples.commentinheritance.Carnivorous.eat(com.microsoft.samples.commentinheritance.Animal)
-  fullName: com.microsoft.samples.commentinheritance.Carnivorous.eat(Animal animalBeingEaten)
-  name: eat(Animal animalBeingEaten)
-  nameWithType: Carnivorous.eat(Animal animalBeingEaten)
-  summary: Eat the provided animal.
+- uid: "com.microsoft.samples.commentinheritance.Carnivorous.eat(com.microsoft.samples.commentinheritance.Animal)"
+  fullName: "com.microsoft.samples.commentinheritance.Carnivorous.eat(Animal animalBeingEaten)"
+  name: "eat(Animal animalBeingEaten)"
+  nameWithType: "Carnivorous.eat(Animal animalBeingEaten)"
+  summary: "Eat the provided animal."
   parameters:
-  - description: Animal that will be eaten.
-    name: animalBeingEaten
-    type: <xref href="com.microsoft.samples.commentinheritance.Animal?alt=com.microsoft.samples.commentinheritance.Animal&text=Animal" data-throw-if-not-resolved="False" />
-  syntax: public abstract void eat(Animal animalBeingEaten)
-type: method
+  - description: "Animal that will be eaten."
+    name: "animalBeingEaten"
+    type: "<xref href=\"com.microsoft.samples.commentinheritance.Animal?alt=com.microsoft.samples.commentinheritance.Animal&text=Animal\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public abstract void eat(Animal animalBeingEaten)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Carnivorous.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Carnivorous.getKind.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Carnivorous.getKind*
-fullName: com.microsoft.samples.commentinheritance.Carnivorous.getKind
-name: getKind
-nameWithType: Carnivorous.getKind
+uid: "com.microsoft.samples.commentinheritance.Carnivorous.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Carnivorous.getKind"
+name: "getKind"
+nameWithType: "Carnivorous.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Carnivorous.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Carnivorous.getKind()
-  name: getKind()
-  nameWithType: Carnivorous.getKind()
-  summary: Get kind from Carnivorous.
-  syntax: public abstract String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Carnivorous.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Carnivorous.getKind()"
+  name: "getKind()"
+  nameWithType: "Carnivorous.getKind()"
+  summary: "Get kind from Carnivorous."
+  syntax: "public abstract String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Carnivorous.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Carnivorous.yml
@@ -1,13 +1,13 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Carnivorous
-fullName: com.microsoft.samples.commentinheritance.Carnivorous
-name: Carnivorous
-nameWithType: Carnivorous
-summary: Marks an Animal that eats other animals.
-syntax: public interface Carnivorous
+uid: "com.microsoft.samples.commentinheritance.Carnivorous"
+fullName: "com.microsoft.samples.commentinheritance.Carnivorous"
+name: "Carnivorous"
+nameWithType: "Carnivorous"
+summary: "Marks an Animal that eats other animals."
+syntax: "public interface Carnivorous"
 methods:
-- com.microsoft.samples.commentinheritance.Carnivorous.eat(com.microsoft.samples.commentinheritance.Animal)
-- com.microsoft.samples.commentinheritance.Carnivorous.getKind()
-type: interface
+- "com.microsoft.samples.commentinheritance.Carnivorous.eat(com.microsoft.samples.commentinheritance.Animal)"
+- "com.microsoft.samples.commentinheritance.Carnivorous.getKind()"
+type: "interface"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.Dog.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.Dog.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Dog.Dog*
-fullName: com.microsoft.samples.commentinheritance.Dog.Dog
-name: Dog
-nameWithType: Dog.Dog
+uid: "com.microsoft.samples.commentinheritance.Dog.Dog*"
+fullName: "com.microsoft.samples.commentinheritance.Dog.Dog"
+name: "Dog"
+nameWithType: "Dog.Dog"
 members:
-- uid: com.microsoft.samples.commentinheritance.Dog.Dog()
-  fullName: com.microsoft.samples.commentinheritance.Dog.Dog()
-  name: Dog()
-  nameWithType: Dog.Dog()
-  syntax: public Dog()
-type: constructor
+- uid: "com.microsoft.samples.commentinheritance.Dog.Dog()"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.Dog()"
+  name: "Dog()"
+  nameWithType: "Dog.Dog()"
+  syntax: "public Dog()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.eat.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.eat.yml
@@ -1,29 +1,29 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Dog.eat*
-fullName: com.microsoft.samples.commentinheritance.Dog.eat
-name: eat
-nameWithType: Dog.eat
+uid: "com.microsoft.samples.commentinheritance.Dog.eat*"
+fullName: "com.microsoft.samples.commentinheritance.Dog.eat"
+name: "eat"
+nameWithType: "Dog.eat"
 members:
-- uid: com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Animal)
-  fullName: com.microsoft.samples.commentinheritance.Dog.eat(Animal otherAnimal)
-  name: eat(Animal otherAnimal)
-  nameWithType: Dog.eat(Animal otherAnimal)
-  summary: Eat the provided animal.
+- uid: "com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Animal)"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.eat(Animal otherAnimal)"
+  name: "eat(Animal otherAnimal)"
+  nameWithType: "Dog.eat(Animal otherAnimal)"
+  summary: "Eat the provided animal."
   parameters:
-  - description: Tasty treat.
-    name: otherAnimal
-    type: <xref href="com.microsoft.samples.commentinheritance.Animal?alt=com.microsoft.samples.commentinheritance.Animal&text=Animal" data-throw-if-not-resolved="False" />
-  syntax: public void eat(Animal otherAnimal)
-- uid: com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)
-  fullName: com.microsoft.samples.commentinheritance.Dog.eat(Herbivorous.Plant plantToBeEaten)
-  name: eat(Herbivorous.Plant plantToBeEaten)
-  nameWithType: Dog.eat(Herbivorous.Plant plantToBeEaten)
-  summary: Eat the provided plant.
+  - description: "Tasty treat."
+    name: "otherAnimal"
+    type: "<xref href=\"com.microsoft.samples.commentinheritance.Animal?alt=com.microsoft.samples.commentinheritance.Animal&text=Animal\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void eat(Animal otherAnimal)"
+- uid: "com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.eat(Herbivorous.Plant plantToBeEaten)"
+  name: "eat(Herbivorous.Plant plantToBeEaten)"
+  nameWithType: "Dog.eat(Herbivorous.Plant plantToBeEaten)"
+  summary: "Eat the provided plant."
   parameters:
-  - description: Plant that this dog will eat.
-    name: plantToBeEaten
-    type: <xref href="com.microsoft.samples.commentinheritance.Herbivorous.Plant?alt=com.microsoft.samples.commentinheritance.Herbivorous.Plant&text=Plant" data-throw-if-not-resolved="False" />
-  syntax: public void eat(Herbivorous.Plant plantToBeEaten)
-type: method
+  - description: "Plant that this dog will eat."
+    name: "plantToBeEaten"
+    type: "<xref href=\"com.microsoft.samples.commentinheritance.Herbivorous.Plant?alt=com.microsoft.samples.commentinheritance.Herbivorous.Plant&text=Plant\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void eat(Herbivorous.Plant plantToBeEaten)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.feed.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.feed.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Dog.feed*
-fullName: com.microsoft.samples.commentinheritance.Dog.feed
-name: feed
-nameWithType: Dog.feed
+uid: "com.microsoft.samples.commentinheritance.Dog.feed*"
+fullName: "com.microsoft.samples.commentinheritance.Dog.feed"
+name: "feed"
+nameWithType: "Dog.feed"
 members:
-- uid: com.microsoft.samples.commentinheritance.Dog.feed()
-  fullName: com.microsoft.samples.commentinheritance.Dog.feed()
-  name: feed()
-  nameWithType: Dog.feed()
-  summary: Feed offspring.
-  overridden: com.microsoft.samples.commentinheritance.Animal.feed()
-  syntax: public void feed()
-type: method
+- uid: "com.microsoft.samples.commentinheritance.Dog.feed()"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.feed()"
+  name: "feed()"
+  nameWithType: "Dog.feed()"
+  summary: "Feed offspring."
+  overridden: "com.microsoft.samples.commentinheritance.Animal.feed()"
+  syntax: "public void feed()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.getHairColor.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.getHairColor.yml
@@ -1,18 +1,18 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Dog.getHairColor*
-fullName: com.microsoft.samples.commentinheritance.Dog.getHairColor
-name: getHairColor
-nameWithType: Dog.getHairColor
+uid: "com.microsoft.samples.commentinheritance.Dog.getHairColor*"
+fullName: "com.microsoft.samples.commentinheritance.Dog.getHairColor"
+name: "getHairColor"
+nameWithType: "Dog.getHairColor"
 members:
-- uid: com.microsoft.samples.commentinheritance.Dog.getHairColor()
-  fullName: com.microsoft.samples.commentinheritance.Dog.getHairColor()
-  name: getHairColor()
-  nameWithType: Dog.getHairColor()
-  summary: Provide the color of the dog's hair.
-  syntax: public Color getHairColor()
+- uid: "com.microsoft.samples.commentinheritance.Dog.getHairColor()"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.getHairColor()"
+  name: "getHairColor()"
+  nameWithType: "Dog.getHairColor()"
+  summary: "Provide the color of the dog's hair."
+  syntax: "public Color getHairColor()"
   returns:
-    description: Color of the dog's fur.
-    type: <xref href="java.awt.Color?alt=java.awt.Color&text=Color" data-throw-if-not-resolved="False" />
-type: method
+    description: "Color of the dog's fur."
+    type: "<xref href=\"java.awt.Color?alt=java.awt.Color&text=Color\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.getKind.yml
@@ -1,22 +1,18 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Dog.getKind*
-fullName: com.microsoft.samples.commentinheritance.Dog.getKind
-name: getKind
-nameWithType: Dog.getKind
+uid: "com.microsoft.samples.commentinheritance.Dog.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Dog.getKind"
+name: "getKind"
+nameWithType: "Dog.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Dog.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Dog.getKind()
-  name: getKind()
-  nameWithType: Dog.getKind()
-  summary: |-
-    Get kind from Organism.
-     Get kind from Animal.
-     Get kind from Mammal.
-     Get kind from Dog.
-  overridden: com.microsoft.samples.commentinheritance.Mammal.getKind()
-  syntax: public String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Dog.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.getKind()"
+  name: "getKind()"
+  nameWithType: "Dog.getKind()"
+  summary: "Get kind from Organism.\n Get kind from Animal.\n Get kind from Mammal.\n Get kind from Dog."
+  overridden: "com.microsoft.samples.commentinheritance.Mammal.getKind()"
+  syntax: "public String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.giveBirth.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.giveBirth.yml
@@ -1,18 +1,18 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Dog.giveBirth*
-fullName: com.microsoft.samples.commentinheritance.Dog.giveBirth
-name: giveBirth
-nameWithType: Dog.giveBirth
+uid: "com.microsoft.samples.commentinheritance.Dog.giveBirth*"
+fullName: "com.microsoft.samples.commentinheritance.Dog.giveBirth"
+name: "giveBirth"
+nameWithType: "Dog.giveBirth"
 members:
-- uid: com.microsoft.samples.commentinheritance.Dog.giveBirth(int)
-  fullName: com.microsoft.samples.commentinheritance.Dog.giveBirth(int numberPuppies)
-  name: giveBirth(int numberPuppies)
-  nameWithType: Dog.giveBirth(int numberPuppies)
+- uid: "com.microsoft.samples.commentinheritance.Dog.giveBirth(int)"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.giveBirth(int numberPuppies)"
+  name: "giveBirth(int numberPuppies)"
+  nameWithType: "Dog.giveBirth(int numberPuppies)"
   parameters:
-  - description: Number of puppies being born.
-    name: numberPuppies
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  syntax: public void giveBirth(int numberPuppies)
-type: method
+  - description: "Number of puppies being born."
+    name: "numberPuppies"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void giveBirth(int numberPuppies)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.verballyCommunicate.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.verballyCommunicate.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Dog.verballyCommunicate*
-fullName: com.microsoft.samples.commentinheritance.Dog.verballyCommunicate
-name: verballyCommunicate
-nameWithType: Dog.verballyCommunicate
+uid: "com.microsoft.samples.commentinheritance.Dog.verballyCommunicate*"
+fullName: "com.microsoft.samples.commentinheritance.Dog.verballyCommunicate"
+name: "verballyCommunicate"
+nameWithType: "Dog.verballyCommunicate"
 members:
-- uid: com.microsoft.samples.commentinheritance.Dog.verballyCommunicate()
-  fullName: com.microsoft.samples.commentinheritance.Dog.verballyCommunicate()
-  name: verballyCommunicate()
-  nameWithType: Dog.verballyCommunicate()
-  summary: Communicate verbally. Bark.
-  overridden: com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()
-  syntax: public void verballyCommunicate()
-type: method
+- uid: "com.microsoft.samples.commentinheritance.Dog.verballyCommunicate()"
+  fullName: "com.microsoft.samples.commentinheritance.Dog.verballyCommunicate()"
+  name: "verballyCommunicate()"
+  nameWithType: "Dog.verballyCommunicate()"
+  summary: "Communicate verbally. Bark."
+  overridden: "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()"
+  syntax: "public void verballyCommunicate()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Dog.yml
@@ -1,43 +1,43 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Dog
-fullName: com.microsoft.samples.commentinheritance.Dog
-name: Dog
-nameWithType: Dog
-summary: Canine and man's best friend.
+uid: "com.microsoft.samples.commentinheritance.Dog"
+fullName: "com.microsoft.samples.commentinheritance.Dog"
+name: "Dog"
+nameWithType: "Dog"
+summary: "Canine and man's best friend."
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.commentinheritance.Animal" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.commentinheritance.Mammal" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.commentinheritance.Animal\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.commentinheritance.Mammal\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- com.microsoft.samples.commentinheritance.Animal.breathe()
-- com.microsoft.samples.commentinheritance.Animal.feed()
-- com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()
-- com.microsoft.samples.commentinheritance.Mammal.getKind()
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class Dog extends Mammal implements Omnivorous, Viviparous
+- "com.microsoft.samples.commentinheritance.Animal.breathe()"
+- "com.microsoft.samples.commentinheritance.Animal.feed()"
+- "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()"
+- "com.microsoft.samples.commentinheritance.Mammal.getKind()"
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class Dog extends Mammal implements Omnivorous, Viviparous"
 constructors:
-- com.microsoft.samples.commentinheritance.Dog.Dog()
+- "com.microsoft.samples.commentinheritance.Dog.Dog()"
 methods:
-- com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Animal)
-- com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)
-- com.microsoft.samples.commentinheritance.Dog.feed()
-- com.microsoft.samples.commentinheritance.Dog.getHairColor()
-- com.microsoft.samples.commentinheritance.Dog.getKind()
-- com.microsoft.samples.commentinheritance.Dog.giveBirth(int)
-- com.microsoft.samples.commentinheritance.Dog.verballyCommunicate()
-type: class
+- "com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Animal)"
+- "com.microsoft.samples.commentinheritance.Dog.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)"
+- "com.microsoft.samples.commentinheritance.Dog.feed()"
+- "com.microsoft.samples.commentinheritance.Dog.getHairColor()"
+- "com.microsoft.samples.commentinheritance.Dog.getKind()"
+- "com.microsoft.samples.commentinheritance.Dog.giveBirth(int)"
+- "com.microsoft.samples.commentinheritance.Dog.verballyCommunicate()"
+type: "class"
 implements:
-- <xref href="com.microsoft.samples.commentinheritance.Omnivorous?alt=com.microsoft.samples.commentinheritance.Omnivorous&text=Omnivorous" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.commentinheritance.Viviparous?alt=com.microsoft.samples.commentinheritance.Viviparous&text=Viviparous" data-throw-if-not-resolved="False" />
+- "<xref href=\"com.microsoft.samples.commentinheritance.Omnivorous?alt=com.microsoft.samples.commentinheritance.Omnivorous&text=Omnivorous\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.commentinheritance.Viviparous?alt=com.microsoft.samples.commentinheritance.Viviparous&text=Viviparous\" data-throw-if-not-resolved=\"False\" />"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant*
-fullName: com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant
-name: Plant
-nameWithType: Herbivorous.Plant.Plant
+uid: "com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant*"
+fullName: "com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant"
+name: "Plant"
+nameWithType: "Herbivorous.Plant.Plant"
 members:
-- uid: com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant()
-  fullName: com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant()
-  name: Plant()
-  nameWithType: Herbivorous.Plant.Plant()
-  syntax: public Plant()
-type: constructor
+- uid: "com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant()"
+  fullName: "com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant()"
+  name: "Plant()"
+  nameWithType: "Herbivorous.Plant.Plant()"
+  syntax: "public Plant()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.Plant.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.Plant.yml
@@ -1,25 +1,25 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Herbivorous.Plant
-fullName: com.microsoft.samples.commentinheritance.Herbivorous.Plant
-name: Herbivorous.Plant
-nameWithType: Herbivorous.Plant
+uid: "com.microsoft.samples.commentinheritance.Herbivorous.Plant"
+fullName: "com.microsoft.samples.commentinheritance.Herbivorous.Plant"
+name: "Herbivorous.Plant"
+nameWithType: "Herbivorous.Plant"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public static class Herbivorous.Plant
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public static class Herbivorous.Plant"
 constructors:
-- com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant()
-type: class
+- "com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant()"
+type: "class"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.eat.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.eat.yml
@@ -1,19 +1,19 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Herbivorous.eat*
-fullName: com.microsoft.samples.commentinheritance.Herbivorous.eat
-name: eat
-nameWithType: Herbivorous.eat
+uid: "com.microsoft.samples.commentinheritance.Herbivorous.eat*"
+fullName: "com.microsoft.samples.commentinheritance.Herbivorous.eat"
+name: "eat"
+nameWithType: "Herbivorous.eat"
 members:
-- uid: com.microsoft.samples.commentinheritance.Herbivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)
-  fullName: com.microsoft.samples.commentinheritance.Herbivorous.eat(Herbivorous.Plant plantToBeEaten)
-  name: eat(Herbivorous.Plant plantToBeEaten)
-  nameWithType: Herbivorous.eat(Herbivorous.Plant plantToBeEaten)
-  summary: Eat the provided plant.
+- uid: "com.microsoft.samples.commentinheritance.Herbivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)"
+  fullName: "com.microsoft.samples.commentinheritance.Herbivorous.eat(Herbivorous.Plant plantToBeEaten)"
+  name: "eat(Herbivorous.Plant plantToBeEaten)"
+  nameWithType: "Herbivorous.eat(Herbivorous.Plant plantToBeEaten)"
+  summary: "Eat the provided plant."
   parameters:
-  - description: Plant that will be eaten.
-    name: plantToBeEaten
-    type: <xref href="com.microsoft.samples.commentinheritance.Herbivorous.Plant?alt=com.microsoft.samples.commentinheritance.Herbivorous.Plant&text=Plant" data-throw-if-not-resolved="False" />
-  syntax: public abstract void eat(Herbivorous.Plant plantToBeEaten)
-type: method
+  - description: "Plant that will be eaten."
+    name: "plantToBeEaten"
+    type: "<xref href=\"com.microsoft.samples.commentinheritance.Herbivorous.Plant?alt=com.microsoft.samples.commentinheritance.Herbivorous.Plant&text=Plant\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public abstract void eat(Herbivorous.Plant plantToBeEaten)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.getKind.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Herbivorous.getKind*
-fullName: com.microsoft.samples.commentinheritance.Herbivorous.getKind
-name: getKind
-nameWithType: Herbivorous.getKind
+uid: "com.microsoft.samples.commentinheritance.Herbivorous.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Herbivorous.getKind"
+name: "getKind"
+nameWithType: "Herbivorous.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Herbivorous.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Herbivorous.getKind()
-  name: getKind()
-  nameWithType: Herbivorous.getKind()
-  summary: Get kind from Herbivorous.
-  syntax: public abstract String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Herbivorous.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Herbivorous.getKind()"
+  name: "getKind()"
+  nameWithType: "Herbivorous.getKind()"
+  summary: "Get kind from Herbivorous."
+  syntax: "public abstract String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Herbivorous.yml
@@ -1,13 +1,13 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Herbivorous
-fullName: com.microsoft.samples.commentinheritance.Herbivorous
-name: Herbivorous
-nameWithType: Herbivorous
-summary: Marks animals that eat plants.
-syntax: public interface Herbivorous
+uid: "com.microsoft.samples.commentinheritance.Herbivorous"
+fullName: "com.microsoft.samples.commentinheritance.Herbivorous"
+name: "Herbivorous"
+nameWithType: "Herbivorous"
+summary: "Marks animals that eat plants."
+syntax: "public interface Herbivorous"
 methods:
-- com.microsoft.samples.commentinheritance.Herbivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)
-- com.microsoft.samples.commentinheritance.Herbivorous.getKind()
-type: interface
+- "com.microsoft.samples.commentinheritance.Herbivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)"
+- "com.microsoft.samples.commentinheritance.Herbivorous.getKind()"
+type: "interface"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Mammal.Mammal.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Mammal.Mammal.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Mammal.Mammal*
-fullName: com.microsoft.samples.commentinheritance.Mammal.Mammal
-name: Mammal
-nameWithType: Mammal.Mammal
+uid: "com.microsoft.samples.commentinheritance.Mammal.Mammal*"
+fullName: "com.microsoft.samples.commentinheritance.Mammal.Mammal"
+name: "Mammal"
+nameWithType: "Mammal.Mammal"
 members:
-- uid: com.microsoft.samples.commentinheritance.Mammal.Mammal()
-  fullName: com.microsoft.samples.commentinheritance.Mammal.Mammal()
-  name: Mammal()
-  nameWithType: Mammal.Mammal()
-  syntax: public Mammal()
-type: constructor
+- uid: "com.microsoft.samples.commentinheritance.Mammal.Mammal()"
+  fullName: "com.microsoft.samples.commentinheritance.Mammal.Mammal()"
+  name: "Mammal()"
+  nameWithType: "Mammal.Mammal()"
+  syntax: "public Mammal()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Mammal.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Mammal.getKind.yml
@@ -1,21 +1,18 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Mammal.getKind*
-fullName: com.microsoft.samples.commentinheritance.Mammal.getKind
-name: getKind
-nameWithType: Mammal.getKind
+uid: "com.microsoft.samples.commentinheritance.Mammal.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Mammal.getKind"
+name: "getKind"
+nameWithType: "Mammal.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Mammal.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Mammal.getKind()
-  name: getKind()
-  nameWithType: Mammal.getKind()
-  summary: |-
-    Get kind from Organism.
-     Get kind from Animal.
-     Get kind from Mammal.
-  overridden: com.microsoft.samples.commentinheritance.Animal.getKind()
-  syntax: public abstract String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Mammal.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Mammal.getKind()"
+  name: "getKind()"
+  nameWithType: "Mammal.getKind()"
+  summary: "Get kind from Organism.\n Get kind from Animal.\n Get kind from Mammal."
+  overridden: "com.microsoft.samples.commentinheritance.Animal.getKind()"
+  syntax: "public abstract String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Mammal.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Mammal.yml
@@ -1,33 +1,33 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Mammal
-fullName: com.microsoft.samples.commentinheritance.Mammal
-name: Mammal
-nameWithType: Mammal
-summary: Mammal.
+uid: "com.microsoft.samples.commentinheritance.Mammal"
+fullName: "com.microsoft.samples.commentinheritance.Mammal"
+name: "Mammal"
+nameWithType: "Mammal"
+summary: "Mammal."
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.commentinheritance.Animal" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.commentinheritance.Animal\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- com.microsoft.samples.commentinheritance.Animal.breathe()
-- com.microsoft.samples.commentinheritance.Animal.feed()
-- com.microsoft.samples.commentinheritance.Animal.getKind()
-- com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public abstract class Mammal extends Animal
+- "com.microsoft.samples.commentinheritance.Animal.breathe()"
+- "com.microsoft.samples.commentinheritance.Animal.feed()"
+- "com.microsoft.samples.commentinheritance.Animal.getKind()"
+- "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate()"
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public abstract class Mammal extends Animal"
 constructors:
-- com.microsoft.samples.commentinheritance.Mammal.Mammal()
+- "com.microsoft.samples.commentinheritance.Mammal.Mammal()"
 methods:
-- com.microsoft.samples.commentinheritance.Mammal.getKind()
-type: class
+- "com.microsoft.samples.commentinheritance.Mammal.getKind()"
+type: "class"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Omnivorous.eat.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Omnivorous.eat.yml
@@ -1,27 +1,27 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Omnivorous.eat*
-fullName: com.microsoft.samples.commentinheritance.Omnivorous.eat
-name: eat
-nameWithType: Omnivorous.eat
+uid: "com.microsoft.samples.commentinheritance.Omnivorous.eat*"
+fullName: "com.microsoft.samples.commentinheritance.Omnivorous.eat"
+name: "eat"
+nameWithType: "Omnivorous.eat"
 members:
-- uid: com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Animal)
-  fullName: com.microsoft.samples.commentinheritance.Omnivorous.eat(Animal animalToBeEaten)
-  name: eat(Animal animalToBeEaten)
-  nameWithType: Omnivorous.eat(Animal animalToBeEaten)
-  summary: Eat the provided animal.
+- uid: "com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Animal)"
+  fullName: "com.microsoft.samples.commentinheritance.Omnivorous.eat(Animal animalToBeEaten)"
+  name: "eat(Animal animalToBeEaten)"
+  nameWithType: "Omnivorous.eat(Animal animalToBeEaten)"
+  summary: "Eat the provided animal."
   parameters:
-  - name: animalToBeEaten
-    type: <xref href="com.microsoft.samples.commentinheritance.Animal?alt=com.microsoft.samples.commentinheritance.Animal&text=Animal" data-throw-if-not-resolved="False" />
-  syntax: public abstract void eat(Animal animalToBeEaten)
-- uid: com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)
-  fullName: com.microsoft.samples.commentinheritance.Omnivorous.eat(Herbivorous.Plant plantToBeEaten)
-  name: eat(Herbivorous.Plant plantToBeEaten)
-  nameWithType: Omnivorous.eat(Herbivorous.Plant plantToBeEaten)
-  summary: Eat the provided plant.
+  - name: "animalToBeEaten"
+    type: "<xref href=\"com.microsoft.samples.commentinheritance.Animal?alt=com.microsoft.samples.commentinheritance.Animal&text=Animal\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public abstract void eat(Animal animalToBeEaten)"
+- uid: "com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)"
+  fullName: "com.microsoft.samples.commentinheritance.Omnivorous.eat(Herbivorous.Plant plantToBeEaten)"
+  name: "eat(Herbivorous.Plant plantToBeEaten)"
+  nameWithType: "Omnivorous.eat(Herbivorous.Plant plantToBeEaten)"
+  summary: "Eat the provided plant."
   parameters:
-  - name: plantToBeEaten
-    type: <xref href="com.microsoft.samples.commentinheritance.Herbivorous.Plant?alt=com.microsoft.samples.commentinheritance.Herbivorous.Plant&text=Plant" data-throw-if-not-resolved="False" />
-  syntax: public abstract void eat(Herbivorous.Plant plantToBeEaten)
-type: method
+  - name: "plantToBeEaten"
+    type: "<xref href=\"com.microsoft.samples.commentinheritance.Herbivorous.Plant?alt=com.microsoft.samples.commentinheritance.Herbivorous.Plant&text=Plant\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public abstract void eat(Herbivorous.Plant plantToBeEaten)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Omnivorous.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Omnivorous.getKind.yml
@@ -1,19 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Omnivorous.getKind*
-fullName: com.microsoft.samples.commentinheritance.Omnivorous.getKind
-name: getKind
-nameWithType: Omnivorous.getKind
+uid: "com.microsoft.samples.commentinheritance.Omnivorous.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Omnivorous.getKind"
+name: "getKind"
+nameWithType: "Omnivorous.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Omnivorous.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Omnivorous.getKind()
-  name: getKind()
-  nameWithType: Omnivorous.getKind()
-  summary: |-
-    Get kind from Carnivorous.
-     Get kind from Omnivorous.
-  syntax: public abstract String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Omnivorous.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Omnivorous.getKind()"
+  name: "getKind()"
+  nameWithType: "Omnivorous.getKind()"
+  summary: "Get kind from Carnivorous.\n Get kind from Omnivorous."
+  syntax: "public abstract String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Omnivorous.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Omnivorous.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Omnivorous
-fullName: com.microsoft.samples.commentinheritance.Omnivorous
-name: Omnivorous
-nameWithType: Omnivorous
-summary: Eats plants and animals.
-syntax: public interface Omnivorous extends Carnivorous, Herbivorous
+uid: "com.microsoft.samples.commentinheritance.Omnivorous"
+fullName: "com.microsoft.samples.commentinheritance.Omnivorous"
+name: "Omnivorous"
+nameWithType: "Omnivorous"
+summary: "Eats plants and animals."
+syntax: "public interface Omnivorous extends Carnivorous, Herbivorous"
 methods:
-- com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Animal)
-- com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)
-- com.microsoft.samples.commentinheritance.Omnivorous.getKind()
-type: interface
+- "com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Animal)"
+- "com.microsoft.samples.commentinheritance.Omnivorous.eat(com.microsoft.samples.commentinheritance.Herbivorous.Plant)"
+- "com.microsoft.samples.commentinheritance.Omnivorous.getKind()"
+type: "interface"
 implements:
-- <xref href="com.microsoft.samples.commentinheritance.Carnivorous?alt=com.microsoft.samples.commentinheritance.Carnivorous&text=Carnivorous" data-throw-if-not-resolved="False" />
-- <xref href="com.microsoft.samples.commentinheritance.Herbivorous?alt=com.microsoft.samples.commentinheritance.Herbivorous&text=Herbivorous" data-throw-if-not-resolved="False" />
+- "<xref href=\"com.microsoft.samples.commentinheritance.Carnivorous?alt=com.microsoft.samples.commentinheritance.Carnivorous&text=Carnivorous\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"com.microsoft.samples.commentinheritance.Herbivorous?alt=com.microsoft.samples.commentinheritance.Herbivorous&text=Herbivorous\" data-throw-if-not-resolved=\"False\" />"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Organism.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Organism.getKind.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Organism.getKind*
-fullName: com.microsoft.samples.commentinheritance.Organism.getKind
-name: getKind
-nameWithType: Organism.getKind
+uid: "com.microsoft.samples.commentinheritance.Organism.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Organism.getKind"
+name: "getKind"
+nameWithType: "Organism.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Organism.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Organism.getKind()
-  name: getKind()
-  nameWithType: Organism.getKind()
-  summary: Get kind from Organism.
-  syntax: public abstract String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Organism.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Organism.getKind()"
+  name: "getKind()"
+  nameWithType: "Organism.getKind()"
+  summary: "Get kind from Organism."
+  syntax: "public abstract String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Organism.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Organism.yml
@@ -1,11 +1,11 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Organism
-fullName: com.microsoft.samples.commentinheritance.Organism
-name: Organism
-nameWithType: Organism
-syntax: public interface Organism
+uid: "com.microsoft.samples.commentinheritance.Organism"
+fullName: "com.microsoft.samples.commentinheritance.Organism"
+name: "Organism"
+nameWithType: "Organism"
+syntax: "public interface Organism"
 methods:
-- com.microsoft.samples.commentinheritance.Organism.getKind()
-type: interface
+- "com.microsoft.samples.commentinheritance.Organism.getKind()"
+type: "interface"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Viviparous.getKind.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Viviparous.getKind.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Viviparous.getKind*
-fullName: com.microsoft.samples.commentinheritance.Viviparous.getKind
-name: getKind
-nameWithType: Viviparous.getKind
+uid: "com.microsoft.samples.commentinheritance.Viviparous.getKind*"
+fullName: "com.microsoft.samples.commentinheritance.Viviparous.getKind"
+name: "getKind"
+nameWithType: "Viviparous.getKind"
 members:
-- uid: com.microsoft.samples.commentinheritance.Viviparous.getKind()
-  fullName: com.microsoft.samples.commentinheritance.Viviparous.getKind()
-  name: getKind()
-  nameWithType: Viviparous.getKind()
-  summary: Get kind from Viviparous.
-  syntax: public abstract String getKind()
+- uid: "com.microsoft.samples.commentinheritance.Viviparous.getKind()"
+  fullName: "com.microsoft.samples.commentinheritance.Viviparous.getKind()"
+  name: "getKind()"
+  nameWithType: "Viviparous.getKind()"
+  summary: "Get kind from Viviparous."
+  syntax: "public abstract String getKind()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Viviparous.giveBirth.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Viviparous.giveBirth.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.commentinheritance.Viviparous.giveBirth*
-fullName: com.microsoft.samples.commentinheritance.Viviparous.giveBirth
-name: giveBirth
-nameWithType: Viviparous.giveBirth
+uid: "com.microsoft.samples.commentinheritance.Viviparous.giveBirth*"
+fullName: "com.microsoft.samples.commentinheritance.Viviparous.giveBirth"
+name: "giveBirth"
+nameWithType: "Viviparous.giveBirth"
 members:
-- uid: com.microsoft.samples.commentinheritance.Viviparous.giveBirth(int)
-  fullName: com.microsoft.samples.commentinheritance.Viviparous.giveBirth(int numberOfOffspring)
-  name: giveBirth(int numberOfOffspring)
-  nameWithType: Viviparous.giveBirth(int numberOfOffspring)
+- uid: "com.microsoft.samples.commentinheritance.Viviparous.giveBirth(int)"
+  fullName: "com.microsoft.samples.commentinheritance.Viviparous.giveBirth(int numberOfOffspring)"
+  name: "giveBirth(int numberOfOffspring)"
+  nameWithType: "Viviparous.giveBirth(int numberOfOffspring)"
   parameters:
-  - name: numberOfOffspring
-    type: <xref href="int?alt=int&text=int" data-throw-if-not-resolved="False" />
-  syntax: public abstract void giveBirth(int numberOfOffspring)
-type: method
+  - name: "numberOfOffspring"
+    type: "<xref href=\"int?alt=int&text=int\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public abstract void giveBirth(int numberOfOffspring)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Viviparous.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.Viviparous.yml
@@ -1,13 +1,13 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.commentinheritance.Viviparous
-fullName: com.microsoft.samples.commentinheritance.Viviparous
-name: Viviparous
-nameWithType: Viviparous
-summary: Mammals that give birth to young that develop within the mother's body.
-syntax: public interface Viviparous
+uid: "com.microsoft.samples.commentinheritance.Viviparous"
+fullName: "com.microsoft.samples.commentinheritance.Viviparous"
+name: "Viviparous"
+nameWithType: "Viviparous"
+summary: "Mammals that give birth to young that develop within the mother's body."
+syntax: "public interface Viviparous"
 methods:
-- com.microsoft.samples.commentinheritance.Viviparous.getKind()
-- com.microsoft.samples.commentinheritance.Viviparous.giveBirth(int)
-type: interface
+- "com.microsoft.samples.commentinheritance.Viviparous.getKind()"
+- "com.microsoft.samples.commentinheritance.Viviparous.giveBirth(int)"
+type: "interface"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaPackage
-uid: com.microsoft.samples.commentinheritance
-fullName: com.microsoft.samples.commentinheritance
-name: com.microsoft.samples.commentinheritance
+uid: "com.microsoft.samples.commentinheritance"
+fullName: "com.microsoft.samples.commentinheritance"
+name: "com.microsoft.samples.commentinheritance"
 classes:
-- com.microsoft.samples.commentinheritance.Animal
-- com.microsoft.samples.commentinheritance.Dog
-- com.microsoft.samples.commentinheritance.Herbivorous.Plant
-- com.microsoft.samples.commentinheritance.Mammal
+- "com.microsoft.samples.commentinheritance.Animal"
+- "com.microsoft.samples.commentinheritance.Dog"
+- "com.microsoft.samples.commentinheritance.Herbivorous.Plant"
+- "com.microsoft.samples.commentinheritance.Mammal"
 interfaces:
-- com.microsoft.samples.commentinheritance.Carnivorous
-- com.microsoft.samples.commentinheritance.Herbivorous
-- com.microsoft.samples.commentinheritance.Omnivorous
-- com.microsoft.samples.commentinheritance.Organism
-- com.microsoft.samples.commentinheritance.Viviparous
+- "com.microsoft.samples.commentinheritance.Carnivorous"
+- "com.microsoft.samples.commentinheritance.Herbivorous"
+- "com.microsoft.samples.commentinheritance.Omnivorous"
+- "com.microsoft.samples.commentinheritance.Organism"
+- "com.microsoft.samples.commentinheritance.Viviparous"
 metadata: {}
-package: com.microsoft.samples.commentinheritance
+package: "com.microsoft.samples.commentinheritance"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.Offer.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.Offer.yml
@@ -1,15 +1,15 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.offers.Offer.Offer*
-fullName: com.microsoft.samples.offers.Offer.Offer
-name: Offer
-nameWithType: Offer.Offer
+uid: "com.microsoft.samples.offers.Offer.Offer*"
+fullName: "com.microsoft.samples.offers.Offer.Offer"
+name: "Offer"
+nameWithType: "Offer.Offer"
 members:
-- uid: com.microsoft.samples.offers.Offer.Offer()
-  fullName: com.microsoft.samples.offers.Offer.Offer()
-  name: Offer()
-  nameWithType: Offer.Offer()
-  summary: Initializes a new instance of the Offer class.
-  syntax: public Offer()
-type: constructor
+- uid: "com.microsoft.samples.offers.Offer.Offer()"
+  fullName: "com.microsoft.samples.offers.Offer.Offer()"
+  name: "Offer()"
+  nameWithType: "Offer.Offer()"
+  summary: "Initializes a new instance of the Offer class."
+  syntax: "public Offer()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.offers
+package: "com.microsoft.samples.offers"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.getReselleeQualifications.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.getReselleeQualifications.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.offers.Offer.getReselleeQualifications*
-fullName: com.microsoft.samples.offers.Offer.getReselleeQualifications
-name: getReselleeQualifications
-nameWithType: Offer.getReselleeQualifications
+uid: "com.microsoft.samples.offers.Offer.getReselleeQualifications*"
+fullName: "com.microsoft.samples.offers.Offer.getReselleeQualifications"
+name: "getReselleeQualifications"
+nameWithType: "Offer.getReselleeQualifications"
 members:
-- uid: com.microsoft.samples.offers.Offer.getReselleeQualifications()
-  fullName: com.microsoft.samples.offers.Offer.getReselleeQualifications()
-  name: getReselleeQualifications()
-  nameWithType: Offer.getReselleeQualifications()
-  syntax: public String[] getReselleeQualifications()
+- uid: "com.microsoft.samples.offers.Offer.getReselleeQualifications()"
+  fullName: "com.microsoft.samples.offers.Offer.getReselleeQualifications()"
+  name: "getReselleeQualifications()"
+  nameWithType: "Offer.getReselleeQualifications()"
+  syntax: "public String[] getReselleeQualifications()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />[]
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />[]"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.offers
+package: "com.microsoft.samples.offers"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.getResellerQualifications.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.getResellerQualifications.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.offers.Offer.getResellerQualifications*
-fullName: com.microsoft.samples.offers.Offer.getResellerQualifications
-name: getResellerQualifications
-nameWithType: Offer.getResellerQualifications
+uid: "com.microsoft.samples.offers.Offer.getResellerQualifications*"
+fullName: "com.microsoft.samples.offers.Offer.getResellerQualifications"
+name: "getResellerQualifications"
+nameWithType: "Offer.getResellerQualifications"
 members:
-- uid: com.microsoft.samples.offers.Offer.getResellerQualifications()
-  fullName: com.microsoft.samples.offers.Offer.getResellerQualifications()
-  name: getResellerQualifications()
-  nameWithType: Offer.getResellerQualifications()
-  syntax: public String[] getResellerQualifications()
+- uid: "com.microsoft.samples.offers.Offer.getResellerQualifications()"
+  fullName: "com.microsoft.samples.offers.Offer.getResellerQualifications()"
+  name: "getResellerQualifications()"
+  nameWithType: "Offer.getResellerQualifications()"
+  syntax: "public String[] getResellerQualifications()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />[]
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />[]"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.offers
+package: "com.microsoft.samples.offers"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.setReselleeQualifications.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.setReselleeQualifications.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.offers.Offer.setReselleeQualifications*
-fullName: com.microsoft.samples.offers.Offer.setReselleeQualifications
-name: setReselleeQualifications
-nameWithType: Offer.setReselleeQualifications
+uid: "com.microsoft.samples.offers.Offer.setReselleeQualifications*"
+fullName: "com.microsoft.samples.offers.Offer.setReselleeQualifications"
+name: "setReselleeQualifications"
+nameWithType: "Offer.setReselleeQualifications"
 members:
-- uid: com.microsoft.samples.offers.Offer.setReselleeQualifications(java.lang.String[])
-  fullName: com.microsoft.samples.offers.Offer.setReselleeQualifications(String[] value)
-  name: setReselleeQualifications(String[] value)
-  nameWithType: Offer.setReselleeQualifications(String[] value)
+- uid: "com.microsoft.samples.offers.Offer.setReselleeQualifications(java.lang.String[])"
+  fullName: "com.microsoft.samples.offers.Offer.setReselleeQualifications(String[] value)"
+  name: "setReselleeQualifications(String[] value)"
+  nameWithType: "Offer.setReselleeQualifications(String[] value)"
   parameters:
-  - name: value
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />[]
-  syntax: public void setReselleeQualifications(String[] value)
-type: method
+  - name: "value"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />[]"
+  syntax: "public void setReselleeQualifications(String[] value)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.offers
+package: "com.microsoft.samples.offers"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.setResellerQualifications.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.setResellerQualifications.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.offers.Offer.setResellerQualifications*
-fullName: com.microsoft.samples.offers.Offer.setResellerQualifications
-name: setResellerQualifications
-nameWithType: Offer.setResellerQualifications
+uid: "com.microsoft.samples.offers.Offer.setResellerQualifications*"
+fullName: "com.microsoft.samples.offers.Offer.setResellerQualifications"
+name: "setResellerQualifications"
+nameWithType: "Offer.setResellerQualifications"
 members:
-- uid: com.microsoft.samples.offers.Offer.setResellerQualifications(java.lang.String[])
-  fullName: com.microsoft.samples.offers.Offer.setResellerQualifications(String[] value)
-  name: setResellerQualifications(String[] value)
-  nameWithType: Offer.setResellerQualifications(String[] value)
+- uid: "com.microsoft.samples.offers.Offer.setResellerQualifications(java.lang.String[])"
+  fullName: "com.microsoft.samples.offers.Offer.setResellerQualifications(String[] value)"
+  name: "setResellerQualifications(String[] value)"
+  nameWithType: "Offer.setResellerQualifications(String[] value)"
   parameters:
-  - name: value
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />[]
-  syntax: public void setResellerQualifications(String[] value)
-type: method
+  - name: "value"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />[]"
+  syntax: "public void setResellerQualifications(String[] value)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.offers
+package: "com.microsoft.samples.offers"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.offers.Offer.yml
@@ -1,31 +1,31 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.offers.Offer
-fullName: com.microsoft.samples.offers.Offer
-name: Offer
-nameWithType: Offer
-summary: Represents a form of product availability to customer
+uid: "com.microsoft.samples.offers.Offer"
+fullName: "com.microsoft.samples.offers.Offer"
+name: "Offer"
+nameWithType: "Offer"
+summary: "Represents a form of product availability to customer"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class Offer
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class Offer"
 constructors:
-- com.microsoft.samples.offers.Offer.Offer()
+- "com.microsoft.samples.offers.Offer.Offer()"
 methods:
-- com.microsoft.samples.offers.Offer.getReselleeQualifications()
-- com.microsoft.samples.offers.Offer.getResellerQualifications()
-- com.microsoft.samples.offers.Offer.setReselleeQualifications(java.lang.String[])
-- com.microsoft.samples.offers.Offer.setResellerQualifications(java.lang.String[])
-type: class
+- "com.microsoft.samples.offers.Offer.getReselleeQualifications()"
+- "com.microsoft.samples.offers.Offer.getResellerQualifications()"
+- "com.microsoft.samples.offers.Offer.setReselleeQualifications(java.lang.String[])"
+- "com.microsoft.samples.offers.Offer.setResellerQualifications(java.lang.String[])"
+type: "class"
 metadata: {}
-package: com.microsoft.samples.offers
+package: "com.microsoft.samples.offers"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.offers.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.offers.yml
@@ -1,8 +1,8 @@
 ### YamlMime:JavaPackage
-uid: com.microsoft.samples.offers
-fullName: com.microsoft.samples.offers
-name: com.microsoft.samples.offers
+uid: "com.microsoft.samples.offers"
+fullName: "com.microsoft.samples.offers"
+name: "com.microsoft.samples.offers"
 classes:
-- com.microsoft.samples.offers.Offer
+- "com.microsoft.samples.offers.Offer"
 metadata: {}
-package: com.microsoft.samples.offers
+package: "com.microsoft.samples.offers"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage(package).yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage(package).yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaPackage
-uid: com.microsoft.samples.subpackage
-fullName: com.microsoft.samples.subpackage
-name: com.microsoft.samples.subpackage
-summary: This subpackage contains the sample set of classes for testing DocFx doclet.
+uid: "com.microsoft.samples.subpackage"
+fullName: "com.microsoft.samples.subpackage"
+name: "com.microsoft.samples.subpackage"
+summary: "This subpackage contains the sample set of classes for testing DocFx doclet."
 classes:
-- com.microsoft.samples.subpackage.CustomException
-- com.microsoft.samples.subpackage.HttpStatusCode
-- com.microsoft.samples.subpackage.Person
-- com.microsoft.samples.subpackage.Person.IdentificationInfo
-- com.microsoft.samples.subpackage.Tuple
+- "com.microsoft.samples.subpackage.CustomException"
+- "com.microsoft.samples.subpackage.HttpStatusCode"
+- "com.microsoft.samples.subpackage.Person"
+- "com.microsoft.samples.subpackage.Person.IdentificationInfo"
+- "com.microsoft.samples.subpackage.Tuple"
 enums:
-- com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender
+- "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender"
 interfaces:
-- com.microsoft.samples.subpackage.Display
+- "com.microsoft.samples.subpackage.Display"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.CustomException.CustomException.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.CustomException.CustomException.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.CustomException.CustomException*
-fullName: com.microsoft.samples.subpackage.CustomException.CustomException
-name: CustomException
-nameWithType: CustomException.CustomException
+uid: "com.microsoft.samples.subpackage.CustomException.CustomException*"
+fullName: "com.microsoft.samples.subpackage.CustomException.CustomException"
+name: "CustomException"
+nameWithType: "CustomException.CustomException"
 members:
-- uid: com.microsoft.samples.subpackage.CustomException.CustomException(java.lang.String)
-  fullName: com.microsoft.samples.subpackage.CustomException.CustomException(String message)
-  name: CustomException(String message)
-  nameWithType: CustomException.CustomException(String message)
+- uid: "com.microsoft.samples.subpackage.CustomException.CustomException(java.lang.String)"
+  fullName: "com.microsoft.samples.subpackage.CustomException.CustomException(String message)"
+  name: "CustomException(String message)"
+  nameWithType: "CustomException.CustomException(String message)"
   parameters:
-  - name: message
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public CustomException(String message)
-type: constructor
+  - name: "message"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public CustomException(String message)"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.CustomException.makeSomething.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.CustomException.makeSomething.yml
@@ -1,18 +1,18 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.CustomException.makeSomething*
-fullName: com.microsoft.samples.subpackage.CustomException.makeSomething
-name: makeSomething
-nameWithType: CustomException.makeSomething
+uid: "com.microsoft.samples.subpackage.CustomException.makeSomething*"
+fullName: "com.microsoft.samples.subpackage.CustomException.makeSomething"
+name: "makeSomething"
+nameWithType: "CustomException.makeSomething"
 members:
-- uid: com.microsoft.samples.subpackage.CustomException.makeSomething()
-  fullName: com.microsoft.samples.subpackage.CustomException.makeSomething()
-  name: makeSomething()
-  nameWithType: CustomException.makeSomething()
-  summary: We need to have such method that throw exception declared in the same class
-  syntax: public void makeSomething()
+- uid: "com.microsoft.samples.subpackage.CustomException.makeSomething()"
+  fullName: "com.microsoft.samples.subpackage.CustomException.makeSomething()"
+  name: "makeSomething()"
+  nameWithType: "CustomException.makeSomething()"
+  summary: "We need to have such method that throw exception declared in the same class"
+  syntax: "public void makeSomething()"
   exceptions:
-  - description: with reason message
-    type: <xref href="com.microsoft.samples.subpackage.CustomException?alt=com.microsoft.samples.subpackage.CustomException&text=CustomException" data-throw-if-not-resolved="False" />
-type: method
+  - description: "with reason message"
+    type: "<xref href=\"com.microsoft.samples.subpackage.CustomException?alt=com.microsoft.samples.subpackage.CustomException&text=CustomException\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.CustomException.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.CustomException.yml
@@ -1,41 +1,41 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.subpackage.CustomException
-fullName: com.microsoft.samples.subpackage.CustomException
-name: CustomException
-nameWithType: CustomException
+uid: "com.microsoft.samples.subpackage.CustomException"
+fullName: "com.microsoft.samples.subpackage.CustomException"
+name: "CustomException"
+nameWithType: "CustomException"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
-- <xref href="java.lang.Throwable" data-throw-if-not-resolved="False" />
-- <xref href="java.lang.Exception" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"java.lang.Throwable\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"java.lang.Exception\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-- java.lang.Throwable.addSuppressed(java.lang.Throwable)
-- java.lang.Throwable.fillInStackTrace()
-- java.lang.Throwable.getCause()
-- java.lang.Throwable.getLocalizedMessage()
-- java.lang.Throwable.getMessage()
-- java.lang.Throwable.getStackTrace()
-- java.lang.Throwable.getSuppressed()
-- java.lang.Throwable.initCause(java.lang.Throwable)
-- java.lang.Throwable.printStackTrace()
-- java.lang.Throwable.printStackTrace(java.io.PrintStream)
-- java.lang.Throwable.printStackTrace(java.io.PrintWriter)
-- java.lang.Throwable.setStackTrace(java.lang.StackTraceElement[])
-- java.lang.Throwable.toString()
-syntax: public class CustomException extends Exception
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+- "java.lang.Throwable.addSuppressed(java.lang.Throwable)"
+- "java.lang.Throwable.fillInStackTrace()"
+- "java.lang.Throwable.getCause()"
+- "java.lang.Throwable.getLocalizedMessage()"
+- "java.lang.Throwable.getMessage()"
+- "java.lang.Throwable.getStackTrace()"
+- "java.lang.Throwable.getSuppressed()"
+- "java.lang.Throwable.initCause(java.lang.Throwable)"
+- "java.lang.Throwable.printStackTrace()"
+- "java.lang.Throwable.printStackTrace(java.io.PrintStream)"
+- "java.lang.Throwable.printStackTrace(java.io.PrintWriter)"
+- "java.lang.Throwable.setStackTrace(java.lang.StackTraceElement[])"
+- "java.lang.Throwable.toString()"
+syntax: "public class CustomException extends Exception"
 constructors:
-- com.microsoft.samples.subpackage.CustomException.CustomException(java.lang.String)
+- "com.microsoft.samples.subpackage.CustomException.CustomException(java.lang.String)"
 methods:
-- com.microsoft.samples.subpackage.CustomException.makeSomething()
-type: class
+- "com.microsoft.samples.subpackage.CustomException.makeSomething()"
+type: "class"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Display.hide.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Display.hide.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Display.hide*
-fullName: com.microsoft.samples.subpackage.Display<T,R>.hide
-name: hide
-nameWithType: Display<T,R>.hide
+uid: "com.microsoft.samples.subpackage.Display.hide*"
+fullName: "com.microsoft.samples.subpackage.Display<T,R>.hide"
+name: "hide"
+nameWithType: "Display<T,R>.hide"
 members:
-- uid: com.microsoft.samples.subpackage.Display.hide()
-  fullName: com.microsoft.samples.subpackage.Display<T,R>.hide()
-  name: hide()
-  nameWithType: Display<T,R>.hide()
-  syntax: public abstract void hide()
-type: method
+- uid: "com.microsoft.samples.subpackage.Display.hide()"
+  fullName: "com.microsoft.samples.subpackage.Display<T,R>.hide()"
+  name: "hide()"
+  nameWithType: "Display<T,R>.hide()"
+  syntax: "public abstract void hide()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Display.show.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Display.show.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Display.show*
-fullName: com.microsoft.samples.subpackage.Display<T,R>.show
-name: show
-nameWithType: Display<T,R>.show
+uid: "com.microsoft.samples.subpackage.Display.show*"
+fullName: "com.microsoft.samples.subpackage.Display<T,R>.show"
+name: "show"
+nameWithType: "Display<T,R>.show"
 members:
-- uid: com.microsoft.samples.subpackage.Display.show()
-  fullName: com.microsoft.samples.subpackage.Display<T,R>.show()
-  name: show()
-  nameWithType: Display<T,R>.show()
-  syntax: public abstract void show()
-type: method
+- uid: "com.microsoft.samples.subpackage.Display.show()"
+  fullName: "com.microsoft.samples.subpackage.Display<T,R>.show()"
+  name: "show()"
+  nameWithType: "Display<T,R>.show()"
+  syntax: "public abstract void show()"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Display.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Display.yml
@@ -1,22 +1,19 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.subpackage.Display
-fullName: com.microsoft.samples.subpackage.Display<T,R>
-name: Display<T,R>
-nameWithType: Display<T,R>
-summary: |-
-  Do you see some `First` code block?
-
-  Or this `Second` code block?
-syntax: public interface Display<T,R> extends Serializable, List<Person<T>>
+uid: "com.microsoft.samples.subpackage.Display"
+fullName: "com.microsoft.samples.subpackage.Display<T,R>"
+name: "Display<T,R>"
+nameWithType: "Display<T,R>"
+summary: "Do you see some `First` code block?\n\nOr this `Second` code block?"
+syntax: "public interface Display<T,R> extends Serializable, List<Person<T>>"
 methods:
-- com.microsoft.samples.subpackage.Display.hide()
-- com.microsoft.samples.subpackage.Display.show()
-type: interface
+- "com.microsoft.samples.subpackage.Display.hide()"
+- "com.microsoft.samples.subpackage.Display.show()"
+type: "interface"
 typeParameters:
-- name: T
-- name: R
+- name: "T"
+- name: "R"
 implements:
-- <xref href="java.io.Serializable?alt=java.io.Serializable&text=Serializable" data-throw-if-not-resolved="False" />
-- <xref href="java.util.List?alt=java.util.List&text=List" data-throw-if-not-resolved="False" />&lt;<xref href="com.microsoft.samples.subpackage.Person?alt=com.microsoft.samples.subpackage.Person&text=Person" data-throw-if-not-resolved="False" />&lt;<xref href="T?alt=T&text=T" data-throw-if-not-resolved="False" />&gt;&gt;
+- "<xref href=\"java.io.Serializable?alt=java.io.Serializable&text=Serializable\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"java.util.List?alt=java.util.List&text=List\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"com.microsoft.samples.subpackage.Person?alt=com.microsoft.samples.subpackage.Person&text=Person\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"T?alt=T&text=T\" data-throw-if-not-resolved=\"False\" />&gt;&gt;"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST
-name: BADREQUEST
-nameWithType: HttpStatusCode.BADREQUEST
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST"
+name: "BADREQUEST"
+nameWithType: "HttpStatusCode.BADREQUEST"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST
-  name: BADREQUEST
-  nameWithType: HttpStatusCode.BADREQUEST
-  syntax: public static final int BADREQUEST
-type: field
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST"
+  name: "BADREQUEST"
+  nameWithType: "HttpStatusCode.BADREQUEST"
+  syntax: "public static final int BADREQUEST"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT
-name: CONFLICT
-nameWithType: HttpStatusCode.CONFLICT
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT"
+name: "CONFLICT"
+nameWithType: "HttpStatusCode.CONFLICT"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT
-  name: CONFLICT
-  nameWithType: HttpStatusCode.CONFLICT
-  syntax: public static final int CONFLICT
-type: field
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT"
+  name: "CONFLICT"
+  nameWithType: "HttpStatusCode.CONFLICT"
+  syntax: "public static final int CONFLICT"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED
-name: EXPECTATIONFAILED
-nameWithType: HttpStatusCode.EXPECTATIONFAILED
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED"
+name: "EXPECTATIONFAILED"
+nameWithType: "HttpStatusCode.EXPECTATIONFAILED"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED
-  name: EXPECTATIONFAILED
-  nameWithType: HttpStatusCode.EXPECTATIONFAILED
-  syntax: public static final int EXPECTATIONFAILED
-type: field
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED"
+  name: "EXPECTATIONFAILED"
+  nameWithType: "HttpStatusCode.EXPECTATIONFAILED"
+  syntax: "public static final int EXPECTATIONFAILED"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN
-name: FORBIDDEN
-nameWithType: HttpStatusCode.FORBIDDEN
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN"
+name: "FORBIDDEN"
+nameWithType: "HttpStatusCode.FORBIDDEN"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN
-  name: FORBIDDEN
-  nameWithType: HttpStatusCode.FORBIDDEN
-  syntax: public static final int FORBIDDEN
-type: field
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN"
+  name: "FORBIDDEN"
+  nameWithType: "HttpStatusCode.FORBIDDEN"
+  syntax: "public static final int FORBIDDEN"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode*
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode
-name: HttpStatusCode
-nameWithType: HttpStatusCode.HttpStatusCode
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode*"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode"
+name: "HttpStatusCode"
+nameWithType: "HttpStatusCode.HttpStatusCode"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode()
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode()
-  name: HttpStatusCode()
-  nameWithType: HttpStatusCode.HttpStatusCode()
-  syntax: public HttpStatusCode()
-type: constructor
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode()"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode()"
+  name: "HttpStatusCode()"
+  nameWithType: "HttpStatusCode.HttpStatusCode()"
+  syntax: "public HttpStatusCode()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND
-name: NOTFOUND
-nameWithType: HttpStatusCode.NOTFOUND
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND"
+name: "NOTFOUND"
+nameWithType: "HttpStatusCode.NOTFOUND"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND
-  name: NOTFOUND
-  nameWithType: HttpStatusCode.NOTFOUND
-  syntax: public static final int NOTFOUND
-type: field
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND"
+  name: "NOTFOUND"
+  nameWithType: "HttpStatusCode.NOTFOUND"
+  syntax: "public static final int NOTFOUND"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE
-name: SERVICEUNAVAILABLE
-nameWithType: HttpStatusCode.SERVICEUNAVAILABLE
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE"
+name: "SERVICEUNAVAILABLE"
+nameWithType: "HttpStatusCode.SERVICEUNAVAILABLE"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE
-  name: SERVICEUNAVAILABLE
-  nameWithType: HttpStatusCode.SERVICEUNAVAILABLE
-  syntax: public static final int SERVICEUNAVAILABLE
-type: field
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE"
+  name: "SERVICEUNAVAILABLE"
+  nameWithType: "HttpStatusCode.SERVICEUNAVAILABLE"
+  syntax: "public static final int SERVICEUNAVAILABLE"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED
-fullName: com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED
-name: UNAUTHORIZED
-nameWithType: HttpStatusCode.UNAUTHORIZED
+uid: "com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED"
+name: "UNAUTHORIZED"
+nameWithType: "HttpStatusCode.UNAUTHORIZED"
 members:
-- uid: com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED
-  fullName: com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED
-  name: UNAUTHORIZED
-  nameWithType: HttpStatusCode.UNAUTHORIZED
-  syntax: public static final int UNAUTHORIZED
-type: field
+- uid: "com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED"
+  fullName: "com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED"
+  name: "UNAUTHORIZED"
+  nameWithType: "HttpStatusCode.UNAUTHORIZED"
+  syntax: "public static final int UNAUTHORIZED"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.HttpStatusCode.yml
@@ -1,33 +1,33 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.subpackage.HttpStatusCode
-fullName: com.microsoft.samples.subpackage.HttpStatusCode
-name: HttpStatusCode
-nameWithType: HttpStatusCode
+uid: "com.microsoft.samples.subpackage.HttpStatusCode"
+fullName: "com.microsoft.samples.subpackage.HttpStatusCode"
+name: "HttpStatusCode"
+nameWithType: "HttpStatusCode"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class HttpStatusCode
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class HttpStatusCode"
 constructors:
-- com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode()
+- "com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode()"
 fields:
-- com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST
-- com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT
-- com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED
-- com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN
-- com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND
-- com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE
-- com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED
-type: class
+- "com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST"
+- "com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT"
+- "com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED"
+- "com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN"
+- "com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND"
+- "com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE"
+- "com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED"
+type: "class"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.yml
@@ -1,56 +1,56 @@
 ### YamlMime:JavaEnum
-uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender
-fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender
-name: Person.IdentificationInfo.Gender
-nameWithType: Person.IdentificationInfo.Gender
-summary: Enum describes person's gender
+uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender"
+fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender"
+name: "Person.IdentificationInfo.Gender"
+nameWithType: "Person.IdentificationInfo.Gender"
+summary: "Enum describes person's gender"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
-- <xref href="java.lang.Enum" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
+- "<xref href=\"java.lang.Enum\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Enum.<T>valueOf(java.lang.Class<T>,java.lang.String)
-- java.lang.Enum.clone()
-- java.lang.Enum.compareTo(E)
-- java.lang.Enum.equals(java.lang.Object)
-- java.lang.Enum.finalize()
-- java.lang.Enum.getDeclaringClass()
-- java.lang.Enum.hashCode()
-- java.lang.Enum.name()
-- java.lang.Enum.ordinal()
-- java.lang.Enum.toString()
-- java.lang.Object.getClass()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public enum Person.IdentificationInfo.Gender extends Enum<Person.IdentificationInfo.Gender>
+- "java.lang.Enum.<T>valueOf(java.lang.Class<T>,java.lang.String)"
+- "java.lang.Enum.clone()"
+- "java.lang.Enum.compareTo(E)"
+- "java.lang.Enum.equals(java.lang.Object)"
+- "java.lang.Enum.finalize()"
+- "java.lang.Enum.getDeclaringClass()"
+- "java.lang.Enum.hashCode()"
+- "java.lang.Enum.name()"
+- "java.lang.Enum.ordinal()"
+- "java.lang.Enum.toString()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public enum Person.IdentificationInfo.Gender extends Enum<Person.IdentificationInfo.Gender>"
 fields:
-- uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.FEMALE
-  fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.FEMALE
-  name: FEMALE
-  nameWithType: Person.IdentificationInfo.Gender.FEMALE
-- uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.MALE
-  fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.MALE
-  name: MALE
-  nameWithType: Person.IdentificationInfo.Gender.MALE
+- uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.FEMALE"
+  fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.FEMALE"
+  name: "FEMALE"
+  nameWithType: "Person.IdentificationInfo.Gender.FEMALE"
+- uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.MALE"
+  fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.MALE"
+  name: "MALE"
+  nameWithType: "Person.IdentificationInfo.Gender.MALE"
 methods:
-- uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.valueOf(java.lang.String)
-  fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.valueOf(String name)
-  name: valueOf(String name)
-  nameWithType: Person.IdentificationInfo.Gender.valueOf(String name)
+- uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.valueOf(java.lang.String)"
+  fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.valueOf(String name)"
+  name: "valueOf(String name)"
+  nameWithType: "Person.IdentificationInfo.Gender.valueOf(String name)"
   parameters:
-  - name: name
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public static Person.IdentificationInfo.Gender valueOf(String name)
+  - name: "name"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public static Person.IdentificationInfo.Gender valueOf(String name)"
   returns:
-    type: <xref href="com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender?alt=com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender&text=Gender" data-throw-if-not-resolved="False" />
-- uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.values()
-  fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.values()
-  name: values()
-  nameWithType: Person.IdentificationInfo.Gender.values()
-  syntax: public static Person.IdentificationInfo.Gender[] values()
+    type: "<xref href=\"com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender?alt=com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender&text=Gender\" data-throw-if-not-resolved=\"False\" />"
+- uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.values()"
+  fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender.values()"
+  name: "values()"
+  nameWithType: "Person.IdentificationInfo.Gender.values()"
+  syntax: "public static Person.IdentificationInfo.Gender[] values()"
   returns:
-    type: <xref href="com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender?alt=com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender&text=Gender" data-throw-if-not-resolved="False" />[]
+    type: "<xref href=\"com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender?alt=com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender&text=Gender\" data-throw-if-not-resolved=\"False\" />[]"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo*
-fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo
-name: IdentificationInfo
-nameWithType: Person.IdentificationInfo.IdentificationInfo
+uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo*"
+fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo"
+name: "IdentificationInfo"
+nameWithType: "Person.IdentificationInfo.IdentificationInfo"
 members:
-- uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo()
-  fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo()
-  name: IdentificationInfo()
-  nameWithType: Person.IdentificationInfo.IdentificationInfo()
-  syntax: public IdentificationInfo()
-type: constructor
+- uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo()"
+  fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo()"
+  name: "IdentificationInfo()"
+  nameWithType: "Person.IdentificationInfo.IdentificationInfo()"
+  syntax: "public IdentificationInfo()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.IdentificationInfo.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.IdentificationInfo.yml
@@ -1,26 +1,26 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.subpackage.Person.IdentificationInfo
-fullName: com.microsoft.samples.subpackage.Person.IdentificationInfo
-name: Person.IdentificationInfo
-nameWithType: Person.IdentificationInfo
-summary: Class that describes person's identification
+uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo"
+fullName: "com.microsoft.samples.subpackage.Person.IdentificationInfo"
+name: "Person.IdentificationInfo"
+nameWithType: "Person.IdentificationInfo"
+summary: "Class that describes person's identification"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public static class Person.IdentificationInfo
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public static class Person.IdentificationInfo"
 constructors:
-- com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo()
-type: class
+- "com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo()"
+type: "class"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.Person.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.Person.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.Person*
-fullName: com.microsoft.samples.subpackage.Person<T>.Person
-name: Person
-nameWithType: Person<T>.Person
+uid: "com.microsoft.samples.subpackage.Person.Person*"
+fullName: "com.microsoft.samples.subpackage.Person<T>.Person"
+name: "Person"
+nameWithType: "Person<T>.Person"
 members:
-- uid: com.microsoft.samples.subpackage.Person.Person()
-  fullName: com.microsoft.samples.subpackage.Person<T>.Person()
-  name: Person()
-  nameWithType: Person<T>.Person()
-  syntax: public Person()
-type: constructor
+- uid: "com.microsoft.samples.subpackage.Person.Person()"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.Person()"
+  name: "Person()"
+  nameWithType: "Person<T>.Person()"
+  syntax: "public Person()"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.age.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.age.yml
@@ -1,14 +1,14 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.age
-fullName: com.microsoft.samples.subpackage.Person<T>.age
-name: age
-nameWithType: Person<T>.age
+uid: "com.microsoft.samples.subpackage.Person.age"
+fullName: "com.microsoft.samples.subpackage.Person<T>.age"
+name: "age"
+nameWithType: "Person<T>.age"
 members:
-- uid: com.microsoft.samples.subpackage.Person.age
-  fullName: com.microsoft.samples.subpackage.Person<T>.age
-  name: age
-  nameWithType: Person<T>.age
-  syntax: public int age
-type: field
+- uid: "com.microsoft.samples.subpackage.Person.age"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.age"
+  name: "age"
+  nameWithType: "Person<T>.age"
+  syntax: "public int age"
+type: "field"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.buildPerson.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.buildPerson.yml
@@ -1,20 +1,20 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.buildPerson*
-fullName: com.microsoft.samples.subpackage.Person<T>.buildPerson
-name: buildPerson
-nameWithType: Person<T>.buildPerson
+uid: "com.microsoft.samples.subpackage.Person.buildPerson*"
+fullName: "com.microsoft.samples.subpackage.Person<T>.buildPerson"
+name: "buildPerson"
+nameWithType: "Person<T>.buildPerson"
 members:
-- uid: com.microsoft.samples.subpackage.Person.buildPerson(com.microsoft.samples.subpackage.Person)
-  fullName: com.microsoft.samples.subpackage.Person<T>.buildPerson(Person seed)
-  name: buildPerson(Person seed)
-  nameWithType: Person<T>.buildPerson(Person seed)
-  summary: We need to have this method that takes parameter and return types declared in the current class
+- uid: "com.microsoft.samples.subpackage.Person.buildPerson(com.microsoft.samples.subpackage.Person)"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.buildPerson(Person seed)"
+  name: "buildPerson(Person seed)"
+  nameWithType: "Person<T>.buildPerson(Person seed)"
+  summary: "We need to have this method that takes parameter and return types declared in the current class"
   parameters:
-  - name: seed
-    type: <xref href="com.microsoft.samples.subpackage.Person?alt=com.microsoft.samples.subpackage.Person&text=Person" data-throw-if-not-resolved="False" />
-  syntax: public static Person buildPerson(Person seed)
+  - name: "seed"
+    type: "<xref href=\"com.microsoft.samples.subpackage.Person?alt=com.microsoft.samples.subpackage.Person&text=Person\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public static Person buildPerson(Person seed)"
   returns:
-    type: <xref href="com.microsoft.samples.subpackage.Person?alt=com.microsoft.samples.subpackage.Person&text=Person" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"com.microsoft.samples.subpackage.Person?alt=com.microsoft.samples.subpackage.Person&text=Person\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.getFirstName.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.getFirstName.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.getFirstName*
-fullName: com.microsoft.samples.subpackage.Person<T>.getFirstName
-name: getFirstName
-nameWithType: Person<T>.getFirstName
+uid: "com.microsoft.samples.subpackage.Person.getFirstName*"
+fullName: "com.microsoft.samples.subpackage.Person<T>.getFirstName"
+name: "getFirstName"
+nameWithType: "Person<T>.getFirstName"
 members:
-- uid: com.microsoft.samples.subpackage.Person.getFirstName()
-  fullName: com.microsoft.samples.subpackage.Person<T>.getFirstName()
-  name: getFirstName()
-  nameWithType: Person<T>.getFirstName()
-  syntax: public String getFirstName()
+- uid: "com.microsoft.samples.subpackage.Person.getFirstName()"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.getFirstName()"
+  name: "getFirstName()"
+  nameWithType: "Person<T>.getFirstName()"
+  syntax: "public String getFirstName()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.getLastName.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.getLastName.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.getLastName*
-fullName: com.microsoft.samples.subpackage.Person<T>.getLastName
-name: getLastName
-nameWithType: Person<T>.getLastName
+uid: "com.microsoft.samples.subpackage.Person.getLastName*"
+fullName: "com.microsoft.samples.subpackage.Person<T>.getLastName"
+name: "getLastName"
+nameWithType: "Person<T>.getLastName"
 members:
-- uid: com.microsoft.samples.subpackage.Person.getLastName()
-  fullName: com.microsoft.samples.subpackage.Person<T>.getLastName()
-  name: getLastName()
-  nameWithType: Person<T>.getLastName()
-  syntax: public String getLastName()
+- uid: "com.microsoft.samples.subpackage.Person.getLastName()"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.getLastName()"
+  name: "getLastName()"
+  nameWithType: "Person<T>.getLastName()"
+  syntax: "public String getLastName()"
   returns:
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.getSomeSet.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.getSomeSet.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.getSomeSet*
-fullName: com.microsoft.samples.subpackage.Person<T>.getSomeSet
-name: getSomeSet
-nameWithType: Person<T>.getSomeSet
+uid: "com.microsoft.samples.subpackage.Person.getSomeSet*"
+fullName: "com.microsoft.samples.subpackage.Person<T>.getSomeSet"
+name: "getSomeSet"
+nameWithType: "Person<T>.getSomeSet"
 members:
-- uid: com.microsoft.samples.subpackage.Person.getSomeSet()
-  fullName: com.microsoft.samples.subpackage.Person<T>.getSomeSet()
-  name: getSomeSet()
-  nameWithType: Person<T>.getSomeSet()
-  syntax: public Set<String> getSomeSet()
+- uid: "com.microsoft.samples.subpackage.Person.getSomeSet()"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.getSomeSet()"
+  name: "getSomeSet()"
+  nameWithType: "Person<T>.getSomeSet()"
+  syntax: "public Set<String> getSomeSet()"
   returns:
-    type: <xref href="java.util.Set?alt=java.util.Set&text=Set" data-throw-if-not-resolved="False" />&lt;<xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />&gt;
-type: method
+    type: "<xref href=\"java.util.Set?alt=java.util.Set&text=Set\" data-throw-if-not-resolved=\"False\" />&lt;<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />&gt;"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.setFirstName.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.setFirstName.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.setFirstName*
-fullName: com.microsoft.samples.subpackage.Person<T>.setFirstName
-name: setFirstName
-nameWithType: Person<T>.setFirstName
+uid: "com.microsoft.samples.subpackage.Person.setFirstName*"
+fullName: "com.microsoft.samples.subpackage.Person<T>.setFirstName"
+name: "setFirstName"
+nameWithType: "Person<T>.setFirstName"
 members:
-- uid: com.microsoft.samples.subpackage.Person.setFirstName(java.lang.String)
-  fullName: com.microsoft.samples.subpackage.Person<T>.setFirstName(String firstName)
-  name: setFirstName(String firstName)
-  nameWithType: Person<T>.setFirstName(String firstName)
+- uid: "com.microsoft.samples.subpackage.Person.setFirstName(java.lang.String)"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.setFirstName(String firstName)"
+  name: "setFirstName(String firstName)"
+  nameWithType: "Person<T>.setFirstName(String firstName)"
   parameters:
-  - name: firstName
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public void setFirstName(String firstName)
-type: method
+  - name: "firstName"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setFirstName(String firstName)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.setLastName.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.setLastName.yml
@@ -1,22 +1,22 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Person.setLastName*
-fullName: com.microsoft.samples.subpackage.Person<T>.setLastName
-name: setLastName
-nameWithType: Person<T>.setLastName
+uid: "com.microsoft.samples.subpackage.Person.setLastName*"
+fullName: "com.microsoft.samples.subpackage.Person<T>.setLastName"
+name: "setLastName"
+nameWithType: "Person<T>.setLastName"
 members:
-- uid: com.microsoft.samples.subpackage.Person.setLastName()
-  fullName: com.microsoft.samples.subpackage.Person<T>.setLastName()
-  name: setLastName()
-  nameWithType: Person<T>.setLastName()
-  syntax: public void setLastName()
-- uid: com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)
-  fullName: com.microsoft.samples.subpackage.Person<T>.setLastName(String lastName)
-  name: setLastName(String lastName)
-  nameWithType: Person<T>.setLastName(String lastName)
+- uid: "com.microsoft.samples.subpackage.Person.setLastName()"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.setLastName()"
+  name: "setLastName()"
+  nameWithType: "Person<T>.setLastName()"
+  syntax: "public void setLastName()"
+- uid: "com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)"
+  fullName: "com.microsoft.samples.subpackage.Person<T>.setLastName(String lastName)"
+  name: "setLastName(String lastName)"
+  nameWithType: "Person<T>.setLastName(String lastName)"
   parameters:
-  - name: lastName
-    type: <xref href="java.lang.String?alt=java.lang.String&text=String" data-throw-if-not-resolved="False" />
-  syntax: public void setLastName(String lastName)
-type: method
+  - name: "lastName"
+    type: "<xref href=\"java.lang.String?alt=java.lang.String&text=String\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setLastName(String lastName)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Person.yml
@@ -1,53 +1,38 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.subpackage.Person
-fullName: com.microsoft.samples.subpackage.Person<T>
-name: Person<T>
-nameWithType: Person<T>
-summary: |-
-  Class that describes some person This comment has links to:
-
-   *  Owner class <xref uid="com.microsoft.samples.subpackage.Person" data-throw-if-not-resolved="false">Person</xref>
-   *  Its inner class <xref uid="com.microsoft.samples.subpackage.Person.IdentificationInfo" data-throw-if-not-resolved="false">Person.IdentificationInfo</xref>
-   *  Its method <xref uid="com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)" data-throw-if-not-resolved="false">Person#setLastName(String lastName)</xref>
-   *  Its method without params <xref uid="com.microsoft.samples.subpackage.Person.setLastName()" data-throw-if-not-resolved="false">Person#setLastName()</xref>
-   *  Its public field <xref uid="com.microsoft.samples.subpackage.Person.age" data-throw-if-not-resolved="false">Person#age</xref>
-   *  Another class which used here <xref uid="java.util.Set" data-throw-if-not-resolved="false">Set</xref>
-   *  Another class which not used here <xref uid="java.util.List" data-throw-if-not-resolved="false">List</xref>
-   *  Broken link <xref uid="" data-throw-if-not-resolved="false">sdfdsagdsfghfgh</xref>
-   *  Plain link <xref uid="" data-throw-if-not-resolved="false">someContent</xref>
-   *  Link that starts from '\#' <xref uid="com.microsoft.samples.subpackage.Person.setLastName()" data-throw-if-not-resolved="false">#setLastName()</xref>
-   *  Link with label <xref uid="java.util.Set" data-throw-if-not-resolved="false">WordOne</xref>
-
-  This is an "at" symbol: @
+uid: "com.microsoft.samples.subpackage.Person"
+fullName: "com.microsoft.samples.subpackage.Person<T>"
+name: "Person<T>"
+nameWithType: "Person<T>"
+summary: "Class that describes some person This comment has links to:\n\n *  Owner class <xref uid=\"com.microsoft.samples.subpackage.Person\" data-throw-if-not-resolved=\"false\">Person</xref>\n *  Its inner class <xref uid=\"com.microsoft.samples.subpackage.Person.IdentificationInfo\" data-throw-if-not-resolved=\"false\">Person.IdentificationInfo</xref>\n *  Its method <xref uid=\"com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)\" data-throw-if-not-resolved=\"false\">Person#setLastName(String lastName)</xref>\n *  Its method without params <xref uid=\"com.microsoft.samples.subpackage.Person.setLastName()\" data-throw-if-not-resolved=\"false\">Person#setLastName()</xref>\n *  Its public field <xref uid=\"com.microsoft.samples.subpackage.Person.age\" data-throw-if-not-resolved=\"false\">Person#age</xref>\n *  Another class which used here <xref uid=\"java.util.Set\" data-throw-if-not-resolved=\"false\">Set</xref>\n *  Another class which not used here <xref uid=\"java.util.List\" data-throw-if-not-resolved=\"false\">List</xref>\n *  Broken link <xref uid=\"\" data-throw-if-not-resolved=\"false\">sdfdsagdsfghfgh</xref>\n *  Plain link <xref uid=\"\" data-throw-if-not-resolved=\"false\">someContent</xref>\n *  Link that starts from '\\#' <xref uid=\"com.microsoft.samples.subpackage.Person.setLastName()\" data-throw-if-not-resolved=\"false\">#setLastName()</xref>\n *  Link with label <xref uid=\"java.util.Set\" data-throw-if-not-resolved=\"false\">WordOne</xref>\n\nThis is an \"at\" symbol: @"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class Person<T>
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class Person<T>"
 constructors:
-- com.microsoft.samples.subpackage.Person.Person()
+- "com.microsoft.samples.subpackage.Person.Person()"
 fields:
-- com.microsoft.samples.subpackage.Person.age
+- "com.microsoft.samples.subpackage.Person.age"
 methods:
-- com.microsoft.samples.subpackage.Person.buildPerson(com.microsoft.samples.subpackage.Person)
-- com.microsoft.samples.subpackage.Person.getFirstName()
-- com.microsoft.samples.subpackage.Person.getLastName()
-- com.microsoft.samples.subpackage.Person.getSomeSet()
-- com.microsoft.samples.subpackage.Person.setFirstName(java.lang.String)
-- com.microsoft.samples.subpackage.Person.setLastName()
-- com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)
-type: class
+- "com.microsoft.samples.subpackage.Person.buildPerson(com.microsoft.samples.subpackage.Person)"
+- "com.microsoft.samples.subpackage.Person.getFirstName()"
+- "com.microsoft.samples.subpackage.Person.getLastName()"
+- "com.microsoft.samples.subpackage.Person.getSomeSet()"
+- "com.microsoft.samples.subpackage.Person.setFirstName(java.lang.String)"
+- "com.microsoft.samples.subpackage.Person.setLastName()"
+- "com.microsoft.samples.subpackage.Person.setLastName(java.lang.String)"
+type: "class"
 typeParameters:
-- name: T
+- name: "T"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.Tuple.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.Tuple.yml
@@ -1,19 +1,19 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Tuple.Tuple*
-fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.Tuple
-name: Tuple
-nameWithType: Tuple<T1,T2>.Tuple
+uid: "com.microsoft.samples.subpackage.Tuple.Tuple*"
+fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.Tuple"
+name: "Tuple"
+nameWithType: "Tuple<T1,T2>.Tuple"
 members:
-- uid: com.microsoft.samples.subpackage.Tuple.Tuple(T1,T2)
-  fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.Tuple(T1 item1, T2 item2)
-  name: Tuple(T1 item1, T2 item2)
-  nameWithType: Tuple<T1,T2>.Tuple(T1 item1, T2 item2)
+- uid: "com.microsoft.samples.subpackage.Tuple.Tuple(T1,T2)"
+  fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.Tuple(T1 item1, T2 item2)"
+  name: "Tuple(T1 item1, T2 item2)"
+  nameWithType: "Tuple<T1,T2>.Tuple(T1 item1, T2 item2)"
   parameters:
-  - name: item1
-    type: <xref href="T1?alt=T1&text=T1" data-throw-if-not-resolved="False" />
-  - name: item2
-    type: <xref href="T2?alt=T2&text=T2" data-throw-if-not-resolved="False" />
-  syntax: public Tuple(T1 item1, T2 item2)
-type: constructor
+  - name: "item1"
+    type: "<xref href=\"T1?alt=T1&text=T1\" data-throw-if-not-resolved=\"False\" />"
+  - name: "item2"
+    type: "<xref href=\"T2?alt=T2&text=T2\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public Tuple(T1 item1, T2 item2)"
+type: "constructor"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.getItem1.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.getItem1.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Tuple.getItem1*
-fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem1
-name: getItem1
-nameWithType: Tuple<T1,T2>.getItem1
+uid: "com.microsoft.samples.subpackage.Tuple.getItem1*"
+fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem1"
+name: "getItem1"
+nameWithType: "Tuple<T1,T2>.getItem1"
 members:
-- uid: com.microsoft.samples.subpackage.Tuple.getItem1()
-  fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem1()
-  name: getItem1()
-  nameWithType: Tuple<T1,T2>.getItem1()
-  syntax: public T1 getItem1()
+- uid: "com.microsoft.samples.subpackage.Tuple.getItem1()"
+  fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem1()"
+  name: "getItem1()"
+  nameWithType: "Tuple<T1,T2>.getItem1()"
+  syntax: "public T1 getItem1()"
   returns:
-    type: <xref href="T1?alt=T1&text=T1" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"T1?alt=T1&text=T1\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.getItem2.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.getItem2.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Tuple.getItem2*
-fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem2
-name: getItem2
-nameWithType: Tuple<T1,T2>.getItem2
+uid: "com.microsoft.samples.subpackage.Tuple.getItem2*"
+fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem2"
+name: "getItem2"
+nameWithType: "Tuple<T1,T2>.getItem2"
 members:
-- uid: com.microsoft.samples.subpackage.Tuple.getItem2()
-  fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem2()
-  name: getItem2()
-  nameWithType: Tuple<T1,T2>.getItem2()
-  syntax: public T2 getItem2()
+- uid: "com.microsoft.samples.subpackage.Tuple.getItem2()"
+  fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.getItem2()"
+  name: "getItem2()"
+  nameWithType: "Tuple<T1,T2>.getItem2()"
+  syntax: "public T2 getItem2()"
   returns:
-    type: <xref href="T2?alt=T2&text=T2" data-throw-if-not-resolved="False" />
-type: method
+    type: "<xref href=\"T2?alt=T2&text=T2\" data-throw-if-not-resolved=\"False\" />"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.setItem1.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.setItem1.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Tuple.setItem1*
-fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem1
-name: setItem1
-nameWithType: Tuple<T1,T2>.setItem1
+uid: "com.microsoft.samples.subpackage.Tuple.setItem1*"
+fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem1"
+name: "setItem1"
+nameWithType: "Tuple<T1,T2>.setItem1"
 members:
-- uid: com.microsoft.samples.subpackage.Tuple.setItem1(T1)
-  fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem1(T1 item1)
-  name: setItem1(T1 item1)
-  nameWithType: Tuple<T1,T2>.setItem1(T1 item1)
+- uid: "com.microsoft.samples.subpackage.Tuple.setItem1(T1)"
+  fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem1(T1 item1)"
+  name: "setItem1(T1 item1)"
+  nameWithType: "Tuple<T1,T2>.setItem1(T1 item1)"
   parameters:
-  - name: item1
-    type: <xref href="T1?alt=T1&text=T1" data-throw-if-not-resolved="False" />
-  syntax: public void setItem1(T1 item1)
-type: method
+  - name: "item1"
+    type: "<xref href=\"T1?alt=T1&text=T1\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setItem1(T1 item1)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.setItem2.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.setItem2.yml
@@ -1,17 +1,17 @@
 ### YamlMime:JavaMember
-uid: com.microsoft.samples.subpackage.Tuple.setItem2*
-fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem2
-name: setItem2
-nameWithType: Tuple<T1,T2>.setItem2
+uid: "com.microsoft.samples.subpackage.Tuple.setItem2*"
+fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem2"
+name: "setItem2"
+nameWithType: "Tuple<T1,T2>.setItem2"
 members:
-- uid: com.microsoft.samples.subpackage.Tuple.setItem2(T2)
-  fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem2(T2 item2)
-  name: setItem2(T2 item2)
-  nameWithType: Tuple<T1,T2>.setItem2(T2 item2)
+- uid: "com.microsoft.samples.subpackage.Tuple.setItem2(T2)"
+  fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>.setItem2(T2 item2)"
+  name: "setItem2(T2 item2)"
+  nameWithType: "Tuple<T1,T2>.setItem2(T2 item2)"
   parameters:
-  - name: item2
-    type: <xref href="T2?alt=T2&text=T2" data-throw-if-not-resolved="False" />
-  syntax: public void setItem2(T2 item2)
-type: method
+  - name: "item2"
+    type: "<xref href=\"T2?alt=T2&text=T2\" data-throw-if-not-resolved=\"False\" />"
+  syntax: "public void setItem2(T2 item2)"
+type: "method"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.Tuple.yml
@@ -1,33 +1,33 @@
 ### YamlMime:JavaType
-uid: com.microsoft.samples.subpackage.Tuple
-fullName: com.microsoft.samples.subpackage.Tuple<T1,T2>
-name: Tuple<T1,T2>
-nameWithType: Tuple<T1,T2>
+uid: "com.microsoft.samples.subpackage.Tuple"
+fullName: "com.microsoft.samples.subpackage.Tuple<T1,T2>"
+name: "Tuple<T1,T2>"
+nameWithType: "Tuple<T1,T2>"
 inheritances:
-- <xref href="java.lang.Object" data-throw-if-not-resolved="False" />
+- "<xref href=\"java.lang.Object\" data-throw-if-not-resolved=\"False\" />"
 inheritedMembers:
-- java.lang.Object.clone()
-- java.lang.Object.equals(java.lang.Object)
-- java.lang.Object.finalize()
-- java.lang.Object.getClass()
-- java.lang.Object.hashCode()
-- java.lang.Object.notify()
-- java.lang.Object.notifyAll()
-- java.lang.Object.toString()
-- java.lang.Object.wait()
-- java.lang.Object.wait(long)
-- java.lang.Object.wait(long,int)
-syntax: public class Tuple<T1,T2>
+- "java.lang.Object.clone()"
+- "java.lang.Object.equals(java.lang.Object)"
+- "java.lang.Object.finalize()"
+- "java.lang.Object.getClass()"
+- "java.lang.Object.hashCode()"
+- "java.lang.Object.notify()"
+- "java.lang.Object.notifyAll()"
+- "java.lang.Object.toString()"
+- "java.lang.Object.wait()"
+- "java.lang.Object.wait(long)"
+- "java.lang.Object.wait(long,int)"
+syntax: "public class Tuple<T1,T2>"
 constructors:
-- com.microsoft.samples.subpackage.Tuple.Tuple(T1,T2)
+- "com.microsoft.samples.subpackage.Tuple.Tuple(T1,T2)"
 methods:
-- com.microsoft.samples.subpackage.Tuple.getItem1()
-- com.microsoft.samples.subpackage.Tuple.getItem2()
-- com.microsoft.samples.subpackage.Tuple.setItem1(T1)
-- com.microsoft.samples.subpackage.Tuple.setItem2(T2)
-type: class
+- "com.microsoft.samples.subpackage.Tuple.getItem1()"
+- "com.microsoft.samples.subpackage.Tuple.getItem2()"
+- "com.microsoft.samples.subpackage.Tuple.setItem1(T1)"
+- "com.microsoft.samples.subpackage.Tuple.setItem2(T2)"
+type: "class"
 typeParameters:
-- name: T1
-- name: T2
+- name: "T1"
+- name: "T2"
 metadata: {}
-package: com.microsoft.samples.subpackage
+package: "com.microsoft.samples.subpackage"

--- a/src/test/resources/expected-generated-files/com.microsoft.samples.yml
+++ b/src/test/resources/expected-generated-files/com.microsoft.samples.yml
@@ -1,16 +1,16 @@
 ### YamlMime:JavaPackage
-uid: com.microsoft.samples
-fullName: com.microsoft.samples
-name: com.microsoft.samples
-summary: This package contains the sample set of classes for testing DocFx doclet.
+uid: "com.microsoft.samples"
+fullName: "com.microsoft.samples"
+name: "com.microsoft.samples"
+summary: "This package contains the sample set of classes for testing DocFx doclet."
 classes:
-- com.microsoft.samples.BasePartnerComponent
-- com.microsoft.samples.BasePartnerComponentString
-- com.microsoft.samples.KeyValuePair
-- com.microsoft.samples.Link
-- com.microsoft.samples.Subpackage
-- com.microsoft.samples.SuperHero
+- "com.microsoft.samples.BasePartnerComponent"
+- "com.microsoft.samples.BasePartnerComponentString"
+- "com.microsoft.samples.KeyValuePair"
+- "com.microsoft.samples.Link"
+- "com.microsoft.samples.Subpackage"
+- "com.microsoft.samples.SuperHero"
 interfaces:
-- com.microsoft.samples.IPartner
+- "com.microsoft.samples.IPartner"
 metadata: {}
-package: com.microsoft.samples
+package: "com.microsoft.samples"

--- a/src/test/resources/expected-generated-files/toc.yml
+++ b/src/test/resources/expected-generated-files/toc.yml
@@ -1,378 +1,381 @@
 ### YamlMime:TableOfContent
-- uid: com.microsoft.samples.agreements
-  name: com.microsoft.samples.agreements
+- uid: "com.microsoft.samples.agreements"
+  name: "com.microsoft.samples.agreements"
   items:
-  - uid: com.microsoft.samples.agreements.ResourceCollection
-    name: ResourceCollection
+  - uid: "com.microsoft.samples.agreements.ResourceCollection"
+    name: "ResourceCollection"
     items:
-    - uid: com.microsoft.samples.agreements.ResourceCollection.ResourceCollection*
-      name: ResourceCollection
-      type: constructor
-  - uid: com.microsoft.samples.agreements.AgreementMetaData
-    name: AgreementMetaData
+    - uid: "com.microsoft.samples.agreements.ResourceCollection.ResourceCollection*"
+      name: "ResourceCollection"
+      type: "constructor"
+  - uid: "com.microsoft.samples.agreements.AgreementMetaData"
+    name: "AgreementMetaData"
     items:
-    - uid: com.microsoft.samples.agreements.AgreementMetaData.getVersionRank*
-      name: getVersionRank
-      type: method
-    - uid: com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData*
-      name: AgreementMetaData
-      type: constructor
-    - uid: com.microsoft.samples.agreements.AgreementMetaData.setTemplateId*
-      name: setTemplateId
-      type: method
-    - uid: com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink*
-      name: setAgreementLink
-      type: method
-    - uid: com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink*
-      name: getAgreementLink
-      type: method
-    - uid: com.microsoft.samples.agreements.AgreementMetaData.getTemplateId*
-      name: getTemplateId
-      type: method
-    - uid: com.microsoft.samples.agreements.AgreementMetaData.setVersionRank*
-      name: setVersionRank
-      type: method
-  - uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations
-    name: AgreementDetailsCollectionOperations
+    - uid: "com.microsoft.samples.agreements.AgreementMetaData.getVersionRank*"
+      name: "getVersionRank"
+      type: "method"
+    - uid: "com.microsoft.samples.agreements.AgreementMetaData.AgreementMetaData*"
+      name: "AgreementMetaData"
+      type: "constructor"
+    - uid: "com.microsoft.samples.agreements.AgreementMetaData.setTemplateId*"
+      name: "setTemplateId"
+      type: "method"
+    - uid: "com.microsoft.samples.agreements.AgreementMetaData.setAgreementLink*"
+      name: "setAgreementLink"
+      type: "method"
+    - uid: "com.microsoft.samples.agreements.AgreementMetaData.getAgreementLink*"
+      name: "getAgreementLink"
+      type: "method"
+    - uid: "com.microsoft.samples.agreements.AgreementMetaData.getTemplateId*"
+      name: "getTemplateId"
+      type: "method"
+    - uid: "com.microsoft.samples.agreements.AgreementMetaData.setVersionRank*"
+      name: "setVersionRank"
+      type: "method"
+  - uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations"
+    name: "AgreementDetailsCollectionOperations"
     items:
-    - uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get*
-      name: get
-      type: method
-    - uid: com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations*
-      name: AgreementDetailsCollectionOperations
-      type: constructor
-  - uid: com.microsoft.samples.agreements.IAgreementDetailsCollection
-    name: IAgreementDetailsCollection
+    - uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.get*"
+      name: "get"
+      type: "method"
+    - uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations.AgreementDetailsCollectionOperations*"
+      name: "AgreementDetailsCollectionOperations"
+      type: "constructor"
+  - uid: "com.microsoft.samples.agreements.IAgreementDetailsCollection"
+    name: "IAgreementDetailsCollection"
     items:
-    - uid: com.microsoft.samples.agreements.IAgreementDetailsCollection.get*
-      name: get
-      type: method
-- uid: com.microsoft.samples.commentinheritance
-  name: com.microsoft.samples.commentinheritance
+    - uid: "com.microsoft.samples.agreements.IAgreementDetailsCollection.get*"
+      name: "get"
+      type: "method"
+- uid: "com.microsoft.samples.commentinheritance"
+  name: "com.microsoft.samples.commentinheritance"
   items:
-  - uid: com.microsoft.samples.commentinheritance.Herbivorous.Plant
-    name: Herbivorous.Plant
+  - uid: "com.microsoft.samples.commentinheritance.Herbivorous.Plant"
+    name: "Herbivorous.Plant"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant*
-      name: Plant
-      type: constructor
-  - uid: com.microsoft.samples.commentinheritance.Herbivorous
-    name: Herbivorous
+    - uid: "com.microsoft.samples.commentinheritance.Herbivorous.Plant.Plant*"
+      name: "Plant"
+      type: "constructor"
+  - uid: "com.microsoft.samples.commentinheritance.Herbivorous"
+    name: "Herbivorous"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Herbivorous.eat*
-      name: eat
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Herbivorous.getKind*
-      name: getKind
-      type: method
-  - uid: com.microsoft.samples.commentinheritance.Mammal
-    name: Mammal
+    - uid: "com.microsoft.samples.commentinheritance.Herbivorous.eat*"
+      name: "eat"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Herbivorous.getKind*"
+      name: "getKind"
+      type: "method"
+  - uid: "com.microsoft.samples.commentinheritance.Mammal"
+    name: "Mammal"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Mammal.Mammal*
-      name: Mammal
-      type: constructor
-    - uid: com.microsoft.samples.commentinheritance.Mammal.getKind*
-      name: getKind
-      type: method
-  - uid: com.microsoft.samples.commentinheritance.Carnivorous
-    name: Carnivorous
+    - uid: "com.microsoft.samples.commentinheritance.Mammal.Mammal*"
+      name: "Mammal"
+      type: "constructor"
+    - uid: "com.microsoft.samples.commentinheritance.Mammal.getKind*"
+      name: "getKind"
+      type: "method"
+  - uid: "com.microsoft.samples.commentinheritance.Carnivorous"
+    name: "Carnivorous"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Carnivorous.getKind*
-      name: getKind
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Carnivorous.eat*
-      name: eat
-      type: method
-  - uid: com.microsoft.samples.commentinheritance.Omnivorous
-    name: Omnivorous
+    - uid: "com.microsoft.samples.commentinheritance.Carnivorous.getKind*"
+      name: "getKind"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Carnivorous.eat*"
+      name: "eat"
+      type: "method"
+  - uid: "com.microsoft.samples.commentinheritance.Omnivorous"
+    name: "Omnivorous"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Omnivorous.eat*
-      name: eat
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Omnivorous.getKind*
-      name: getKind
-      type: method
-  - uid: com.microsoft.samples.commentinheritance.Animal
-    name: Animal
+    - uid: "com.microsoft.samples.commentinheritance.Omnivorous.eat*"
+      name: "eat"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Omnivorous.getKind*"
+      name: "getKind"
+      type: "method"
+  - uid: "com.microsoft.samples.commentinheritance.Animal"
+    name: "Animal"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Animal.Animal*
-      name: Animal
-      type: constructor
-    - uid: com.microsoft.samples.commentinheritance.Animal.getKind*
-      name: getKind
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Animal.breathe*
-      name: breathe
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Animal.feed*
-      name: feed
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Animal.verballyCommunicate*
-      name: verballyCommunicate
-      type: method
-  - uid: com.microsoft.samples.commentinheritance.Dog
-    name: Dog
+    - uid: "com.microsoft.samples.commentinheritance.Animal.Animal*"
+      name: "Animal"
+      type: "constructor"
+    - uid: "com.microsoft.samples.commentinheritance.Animal.getKind*"
+      name: "getKind"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Animal.breathe*"
+      name: "breathe"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Animal.feed*"
+      name: "feed"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Animal.verballyCommunicate*"
+      name: "verballyCommunicate"
+      type: "method"
+  - uid: "com.microsoft.samples.commentinheritance.Dog"
+    name: "Dog"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Dog.verballyCommunicate*
-      name: verballyCommunicate
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Dog.giveBirth*
-      name: giveBirth
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Dog.feed*
-      name: feed
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Dog.getKind*
-      name: getKind
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Dog.Dog*
-      name: Dog
-      type: constructor
-    - uid: com.microsoft.samples.commentinheritance.Dog.getHairColor*
-      name: getHairColor
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Dog.eat*
-      name: eat
-      type: method
-  - uid: com.microsoft.samples.commentinheritance.Organism
-    name: Organism
+    - uid: "com.microsoft.samples.commentinheritance.Dog.verballyCommunicate*"
+      name: "verballyCommunicate"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Dog.giveBirth*"
+      name: "giveBirth"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Dog.feed*"
+      name: "feed"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Dog.getKind*"
+      name: "getKind"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Dog.Dog*"
+      name: "Dog"
+      type: "constructor"
+    - uid: "com.microsoft.samples.commentinheritance.Dog.getHairColor*"
+      name: "getHairColor"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Dog.eat*"
+      name: "eat"
+      type: "method"
+  - uid: "com.microsoft.samples.commentinheritance.Organism"
+    name: "Organism"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Organism.getKind*
-      name: getKind
-      type: method
-  - uid: com.microsoft.samples.commentinheritance.Viviparous
-    name: Viviparous
+    - uid: "com.microsoft.samples.commentinheritance.Organism.getKind*"
+      name: "getKind"
+      type: "method"
+  - uid: "com.microsoft.samples.commentinheritance.Viviparous"
+    name: "Viviparous"
     items:
-    - uid: com.microsoft.samples.commentinheritance.Viviparous.giveBirth*
-      name: giveBirth
-      type: method
-    - uid: com.microsoft.samples.commentinheritance.Viviparous.getKind*
-      name: getKind
-      type: method
-- uid: com.microsoft.samples.offers
-  name: com.microsoft.samples.offers
+    - uid: "com.microsoft.samples.commentinheritance.Viviparous.giveBirth*"
+      name: "giveBirth"
+      type: "method"
+    - uid: "com.microsoft.samples.commentinheritance.Viviparous.getKind*"
+      name: "getKind"
+      type: "method"
+- uid: "com.microsoft.samples.offers"
+  name: "com.microsoft.samples.offers"
   items:
-  - uid: com.microsoft.samples.offers.Offer
-    name: Offer
+  - uid: "com.microsoft.samples.offers.Offer"
+    name: "Offer"
     items:
-    - uid: com.microsoft.samples.offers.Offer.getResellerQualifications*
-      name: getResellerQualifications
-      type: method
-    - uid: com.microsoft.samples.offers.Offer.setReselleeQualifications*
-      name: setReselleeQualifications
-      type: method
-    - uid: com.microsoft.samples.offers.Offer.Offer*
-      name: Offer
-      type: constructor
-    - uid: com.microsoft.samples.offers.Offer.getReselleeQualifications*
-      name: getReselleeQualifications
-      type: method
-    - uid: com.microsoft.samples.offers.Offer.setResellerQualifications*
-      name: setResellerQualifications
-      type: method
-- uid: com.microsoft.samples
-  name: com.microsoft.samples
+    - uid: "com.microsoft.samples.offers.Offer.getResellerQualifications*"
+      name: "getResellerQualifications"
+      type: "method"
+    - uid: "com.microsoft.samples.offers.Offer.setReselleeQualifications*"
+      name: "setReselleeQualifications"
+      type: "method"
+    - uid: "com.microsoft.samples.offers.Offer.Offer*"
+      name: "Offer"
+      type: "constructor"
+    - uid: "com.microsoft.samples.offers.Offer.getReselleeQualifications*"
+      name: "getReselleeQualifications"
+      type: "method"
+    - uid: "com.microsoft.samples.offers.Offer.setResellerQualifications*"
+      name: "setResellerQualifications"
+      type: "method"
+- uid: "com.microsoft.samples"
+  name: "com.microsoft.samples"
   items:
-  - uid: com.microsoft.samples.KeyValuePair
-    name: KeyValuePair
+  - uid: "com.microsoft.samples.KeyValuePair"
+    name: "KeyValuePair"
     items:
-    - uid: com.microsoft.samples.KeyValuePair.getValue*
-      name: getValue
-      type: method
-    - uid: com.microsoft.samples.KeyValuePair.KeyValuePair*
-      name: KeyValuePair
-      type: constructor
-    - uid: com.microsoft.samples.KeyValuePair.getKey*
-      name: getKey
-      type: method
-  - uid: com.microsoft.samples.IPartner
-    name: IPartner
+    - uid: "com.microsoft.samples.KeyValuePair.getValue*"
+      name: "getValue"
+      type: "method"
+    - uid: "com.microsoft.samples.KeyValuePair.KeyValuePair*"
+      name: "KeyValuePair"
+      type: "constructor"
+    - uid: "com.microsoft.samples.KeyValuePair.getKey*"
+      name: "getKey"
+      type: "method"
+  - uid: "com.microsoft.samples.IPartner"
+    name: "IPartner"
     items:
-    - uid: com.microsoft.samples.IPartner.getCredentials*
-      name: getCredentials
-      type: method
-  - uid: com.microsoft.samples.SuperHero
-    name: SuperHero
+    - uid: "com.microsoft.samples.IPartner.getCredentials*"
+      name: "getCredentials"
+      type: "method"
+  - uid: "com.microsoft.samples.SuperHero"
+    name: "SuperHero"
     items:
-    - uid: com.microsoft.samples.SuperHero.SuperHero*
-      name: SuperHero
-      type: constructor
-    - uid: com.microsoft.samples.SuperHero.setDefense*
-      name: setDefense
-      type: method
-    - uid: com.microsoft.samples.SuperHero.getLastName*
-      name: getLastName
-      type: method
-    - uid: com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING
-      name: SOME_PUBLIC_STRING
-      type: field
-    - uid: com.microsoft.samples.SuperHero.getUniquePower*
-      name: getUniquePower
-      type: method
-    - uid: com.microsoft.samples.SuperHero.setUniquePower*
-      name: setUniquePower
-      type: method
-    - uid: com.microsoft.samples.SuperHero.getHealth*
-      name: getHealth
-      type: method
-    - uid: com.microsoft.samples.SuperHero.getHeroName*
-      name: getHeroName
-      type: method
-    - uid: com.microsoft.samples.SuperHero.setHeroName*
-      name: setHeroName
-      type: method
-    - uid: com.microsoft.samples.SuperHero.setHealth*
-      name: setHealth
-      type: method
-    - uid: com.microsoft.samples.SuperHero.getDefense*
-      name: getDefense
-      type: method
-    - uid: com.microsoft.samples.SuperHero.successfullyAttacked*
-      name: successfullyAttacked
-      type: method
-  - uid: com.microsoft.samples.Subpackage
-    name: Subpackage
+    - uid: "com.microsoft.samples.SuperHero.SOME_PUBLIC_STRING"
+      name: "SOME_PUBLIC_STRING"
+      type: "field"
+    - uid: "com.microsoft.samples.SuperHero.getUniquePower*"
+      name: "getUniquePower"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.setUniquePower*"
+      name: "setUniquePower"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.getHealth*"
+      name: "getHealth"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.getHeroName*"
+      name: "getHeroName"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.setHeroName*"
+      name: "setHeroName"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.setHealth*"
+      name: "setHealth"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.getDefense*"
+      name: "getDefense"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.ReturnNull*"
+      name: "<V>ReturnNull"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.SuperHero*"
+      name: "SuperHero"
+      type: "constructor"
+    - uid: "com.microsoft.samples.SuperHero.setDefense*"
+      name: "setDefense"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.getLastName*"
+      name: "getLastName"
+      type: "method"
+    - uid: "com.microsoft.samples.SuperHero.successfullyAttacked*"
+      name: "successfullyAttacked"
+      type: "method"
+  - uid: "com.microsoft.samples.Subpackage"
+    name: "Subpackage"
     items:
-    - uid: com.microsoft.samples.Subpackage.Subpackage*
-      name: Subpackage
-      type: constructor
-  - uid: com.microsoft.samples.Link
-    name: Link
+    - uid: "com.microsoft.samples.Subpackage.Subpackage*"
+      name: "Subpackage"
+      type: "constructor"
+  - uid: "com.microsoft.samples.Link"
+    name: "Link"
     items:
-    - uid: com.microsoft.samples.Link.setMethod*
-      name: setMethod
-      type: method
-    - uid: com.microsoft.samples.Link.Link*
-      name: Link
-      type: constructor
-    - uid: com.microsoft.samples.Link.getHeaders*
-      name: getHeaders
-      type: method
-    - uid: com.microsoft.samples.Link.getMethod*
-      name: getMethod
-      type: method
-    - uid: com.microsoft.samples.Link.setHeaders*
-      name: setHeaders
-      type: method
-  - uid: com.microsoft.samples.BasePartnerComponentString
-    name: BasePartnerComponentString
+    - uid: "com.microsoft.samples.Link.setMethod*"
+      name: "setMethod"
+      type: "method"
+    - uid: "com.microsoft.samples.Link.Link*"
+      name: "Link"
+      type: "constructor"
+    - uid: "com.microsoft.samples.Link.getHeaders*"
+      name: "getHeaders"
+      type: "method"
+    - uid: "com.microsoft.samples.Link.getMethod*"
+      name: "getMethod"
+      type: "method"
+    - uid: "com.microsoft.samples.Link.setHeaders*"
+      name: "setHeaders"
+      type: "method"
+  - uid: "com.microsoft.samples.BasePartnerComponentString"
+    name: "BasePartnerComponentString"
     items:
-    - uid: com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString*
-      name: BasePartnerComponentString
-      type: constructor
-    - uid: com.microsoft.samples.BasePartnerComponentString.testInherited*
-      name: testInherited
-      type: method
-  - uid: com.microsoft.samples.BasePartnerComponent
-    name: BasePartnerComponent
+    - uid: "com.microsoft.samples.BasePartnerComponentString.BasePartnerComponentString*"
+      name: "BasePartnerComponentString"
+      type: "constructor"
+    - uid: "com.microsoft.samples.BasePartnerComponentString.testInherited*"
+      name: "testInherited"
+      type: "method"
+  - uid: "com.microsoft.samples.BasePartnerComponent"
+    name: "BasePartnerComponent"
     items:
-    - uid: com.microsoft.samples.BasePartnerComponent.testInherited*
-      name: testInherited
-      type: method
-    - uid: com.microsoft.samples.BasePartnerComponent.BasePartnerComponent*
-      name: BasePartnerComponent
-      type: constructor
-    - uid: com.microsoft.samples.BasePartnerComponent.testBase*
-      name: testBase
-      type: method
-- uid: com.microsoft.samples.subpackage
-  name: com.microsoft.samples.subpackage
+    - uid: "com.microsoft.samples.BasePartnerComponent.testInherited*"
+      name: "testInherited"
+      type: "method"
+    - uid: "com.microsoft.samples.BasePartnerComponent.BasePartnerComponent*"
+      name: "BasePartnerComponent"
+      type: "constructor"
+    - uid: "com.microsoft.samples.BasePartnerComponent.testBase*"
+      name: "testBase"
+      type: "method"
+- uid: "com.microsoft.samples.subpackage"
+  name: "com.microsoft.samples.subpackage"
   items:
-  - uid: com.microsoft.samples.subpackage.CustomException
-    name: CustomException
+  - uid: "com.microsoft.samples.subpackage.CustomException"
+    name: "CustomException"
     items:
-    - uid: com.microsoft.samples.subpackage.CustomException.makeSomething*
-      name: makeSomething
-      type: method
-    - uid: com.microsoft.samples.subpackage.CustomException.CustomException*
-      name: CustomException
-      type: constructor
-  - uid: com.microsoft.samples.subpackage.HttpStatusCode
-    name: HttpStatusCode
+    - uid: "com.microsoft.samples.subpackage.CustomException.makeSomething*"
+      name: "makeSomething"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.CustomException.CustomException*"
+      name: "CustomException"
+      type: "constructor"
+  - uid: "com.microsoft.samples.subpackage.HttpStatusCode"
+    name: "HttpStatusCode"
     items:
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED
-      name: UNAUTHORIZED
-      type: field
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND
-      name: NOTFOUND
-      type: field
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT
-      name: CONFLICT
-      type: field
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode*
-      name: HttpStatusCode
-      type: constructor
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE
-      name: SERVICEUNAVAILABLE
-      type: field
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST
-      name: BADREQUEST
-      type: field
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED
-      name: EXPECTATIONFAILED
-      type: field
-    - uid: com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN
-      name: FORBIDDEN
-      type: field
-  - uid: com.microsoft.samples.subpackage.Person
-    name: Person
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.UNAUTHORIZED"
+      name: "UNAUTHORIZED"
+      type: "field"
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.NOTFOUND"
+      name: "NOTFOUND"
+      type: "field"
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.CONFLICT"
+      name: "CONFLICT"
+      type: "field"
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.HttpStatusCode*"
+      name: "HttpStatusCode"
+      type: "constructor"
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.SERVICEUNAVAILABLE"
+      name: "SERVICEUNAVAILABLE"
+      type: "field"
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.BADREQUEST"
+      name: "BADREQUEST"
+      type: "field"
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.EXPECTATIONFAILED"
+      name: "EXPECTATIONFAILED"
+      type: "field"
+    - uid: "com.microsoft.samples.subpackage.HttpStatusCode.FORBIDDEN"
+      name: "FORBIDDEN"
+      type: "field"
+  - uid: "com.microsoft.samples.subpackage.Person"
+    name: "Person"
     items:
-    - uid: com.microsoft.samples.subpackage.Person.getFirstName*
-      name: getFirstName
-      type: method
-    - uid: com.microsoft.samples.subpackage.Person.getSomeSet*
-      name: getSomeSet
-      type: method
-    - uid: com.microsoft.samples.subpackage.Person.age
-      name: age
-      type: field
-    - uid: com.microsoft.samples.subpackage.Person.Person*
-      name: Person
-      type: constructor
-    - uid: com.microsoft.samples.subpackage.Person.setLastName*
-      name: setLastName
-      type: method
-    - uid: com.microsoft.samples.subpackage.Person.setFirstName*
-      name: setFirstName
-      type: method
-    - uid: com.microsoft.samples.subpackage.Person.buildPerson*
-      name: buildPerson
-      type: method
-    - uid: com.microsoft.samples.subpackage.Person.getLastName*
-      name: getLastName
-      type: method
-  - uid: com.microsoft.samples.subpackage.Tuple
-    name: Tuple
+    - uid: "com.microsoft.samples.subpackage.Person.getFirstName*"
+      name: "getFirstName"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Person.getSomeSet*"
+      name: "getSomeSet"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Person.age"
+      name: "age"
+      type: "field"
+    - uid: "com.microsoft.samples.subpackage.Person.Person*"
+      name: "Person"
+      type: "constructor"
+    - uid: "com.microsoft.samples.subpackage.Person.setLastName*"
+      name: "setLastName"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Person.setFirstName*"
+      name: "setFirstName"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Person.buildPerson*"
+      name: "buildPerson"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Person.getLastName*"
+      name: "getLastName"
+      type: "method"
+  - uid: "com.microsoft.samples.subpackage.Tuple"
+    name: "Tuple"
     items:
-    - uid: com.microsoft.samples.subpackage.Tuple.Tuple*
-      name: Tuple
-      type: constructor
-    - uid: com.microsoft.samples.subpackage.Tuple.getItem1*
-      name: getItem1
-      type: method
-    - uid: com.microsoft.samples.subpackage.Tuple.getItem2*
-      name: getItem2
-      type: method
-    - uid: com.microsoft.samples.subpackage.Tuple.setItem1*
-      name: setItem1
-      type: method
-    - uid: com.microsoft.samples.subpackage.Tuple.setItem2*
-      name: setItem2
-      type: method
-  - uid: com.microsoft.samples.subpackage.Person.IdentificationInfo
-    name: Person.IdentificationInfo
+    - uid: "com.microsoft.samples.subpackage.Tuple.Tuple*"
+      name: "Tuple"
+      type: "constructor"
+    - uid: "com.microsoft.samples.subpackage.Tuple.getItem1*"
+      name: "getItem1"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Tuple.getItem2*"
+      name: "getItem2"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Tuple.setItem1*"
+      name: "setItem1"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Tuple.setItem2*"
+      name: "setItem2"
+      type: "method"
+  - uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo"
+    name: "Person.IdentificationInfo"
     items:
-    - uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo*
-      name: IdentificationInfo
-      type: constructor
-  - uid: com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender
-    name: Person.IdentificationInfo.Gender
-  - uid: com.microsoft.samples.subpackage.Display
-    name: Display
+    - uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.IdentificationInfo*"
+      name: "IdentificationInfo"
+      type: "constructor"
+  - uid: "com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender"
+    name: "Person.IdentificationInfo.Gender"
+  - uid: "com.microsoft.samples.subpackage.Display"
+    name: "Display"
     items:
-    - uid: com.microsoft.samples.subpackage.Display.hide*
-      name: hide
-      type: method
-    - uid: com.microsoft.samples.subpackage.Display.show*
-      name: show
-      type: method
+    - uid: "com.microsoft.samples.subpackage.Display.hide*"
+      name: "hide"
+      type: "method"
+    - uid: "com.microsoft.samples.subpackage.Display.show*"
+      name: "show"
+      type: "method"


### PR DESCRIPTION
using double quotes to make sure some Java key words will be handled as string in docs build when they are uses as "name" or "description"