### PR TITLE
update Spring Lib URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <repository>
       <id>sprin-libs-repo</id>
       <name>Spring Lib Release repository</name>
-      <url>https://repo.spring.io/libs-release</url>
+      <url>https://repo.spring.io/libs-snapshot</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
Update Spring Lib URL based on:
https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020