### PR TITLE
Replaced the old repo for anonymous access.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,15 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <skipTests>${skipTests}</skipTests>
+        </configuration>
+      </plugin>
+
       <!-- Pack doclet with dependent libs into fat jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -150,10 +159,10 @@
   </dependencies>
 
   <repositories>
-    <repository>
-      <id>sprin-libs-repo</id>
-      <name>Spring Lib Release repository</name>
-      <url>https://repo.spring.io/libs-release</url>
+     <repository>
+      <id>jcenter</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com</url>
     </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,15 +32,6 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
-        <configuration>
-          <skipTests>${skipTests}</skipTests>
-        </configuration>
-      </plugin>
-
       <!-- Pack doclet with dependent libs into fat jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Anonymous download is no longer supported by JFrog on repo.spring.io. See details below in the links.

@anmeng10101 All tests have passed as attached:
![image](https://user-images.githubusercontent.com/59190910/128350313-75bd37e9-c8b0-4cf0-935d-f58277f8db3f.png)


https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/